### PR TITLE
fix: Using smart pointers instead of raw pointer.

### DIFF
--- a/casbin/enforcer.cpp
+++ b/casbin/enforcer.cpp
@@ -162,9 +162,9 @@ bool Enforcer :: enforce(string matcher, Scope scope) {
 /**
  * Enforcer is the default constructor.
  */
-shared_ptr<Enforcer> Enforcer :: NewEnforcer() {
-    shared_ptr<Enforcer> e = shared_ptr<Enforcer>(new Enforcer());
-    return e;
+unique_ptr<Enforcer> Enforcer ::NewEnforcer() {
+    unique_ptr<Enforcer> e = unique_ptr<Enforcer>(new Enforcer());
+    return move(e);
 }
 
 /**
@@ -173,8 +173,8 @@ shared_ptr<Enforcer> Enforcer :: NewEnforcer() {
  * @param model_path the path of the model file.
  * @param policyFile the path of the policy file.
  */
-shared_ptr<Enforcer> Enforcer :: NewEnforcer(string model_path, string policyFile) {
-    return NewEnforcer(model_path, shared_ptr<FileAdapter>(FileAdapter :: NewAdapter(policyFile)));
+unique_ptr<Enforcer> Enforcer :: NewEnforcer(string model_path, string policyFile) {
+    return move(NewEnforcer(model_path, shared_ptr<FileAdapter>(FileAdapter :: NewAdapter(policyFile))));
 }
 
 /**
@@ -183,10 +183,10 @@ shared_ptr<Enforcer> Enforcer :: NewEnforcer(string model_path, string policyFil
  * @param model_path the path of the model file.
  * @param adapter the adapter.
  */
-shared_ptr<Enforcer> Enforcer :: NewEnforcer(string model_path, shared_ptr<Adapter> adapter) {
-    shared_ptr<Enforcer> e = NewEnforcer(shared_ptr<Model>(Model :: NewModelFromFile(model_path)), adapter);
+unique_ptr<Enforcer> Enforcer :: NewEnforcer(string model_path, shared_ptr<Adapter> adapter) {
+    unique_ptr<Enforcer> e = NewEnforcer(shared_ptr<Model>(Model :: NewModelFromFile(model_path)), adapter);
     e->model_path = model_path;
-    return e;
+    return move(e);
 }
 
 /**
@@ -195,8 +195,8 @@ shared_ptr<Enforcer> Enforcer :: NewEnforcer(string model_path, shared_ptr<Adapt
  * @param m the model.
  * @param adapter the adapter.
  */
-shared_ptr<Enforcer> Enforcer :: NewEnforcer(shared_ptr<Model> m, shared_ptr<Adapter> adapter) {
-    shared_ptr<Enforcer> e = shared_ptr<Enforcer>(new Enforcer());
+unique_ptr<Enforcer> Enforcer :: NewEnforcer(shared_ptr<Model> m, shared_ptr<Adapter> adapter) {
+  unique_ptr<Enforcer> e = unique_ptr<Enforcer>(new Enforcer());
     e->adapter = adapter;
     e->watcher = NULL;
 
@@ -209,7 +209,7 @@ shared_ptr<Enforcer> Enforcer :: NewEnforcer(shared_ptr<Model> m, shared_ptr<Ada
     if (e->adapter->file_path != "") {
         e->LoadPolicy();
     }
-    return e;
+    return move(e);
 }
 
 /**
@@ -217,8 +217,8 @@ shared_ptr<Enforcer> Enforcer :: NewEnforcer(shared_ptr<Model> m, shared_ptr<Ada
  *
  * @param m the model.
  */
-shared_ptr<Enforcer> Enforcer :: NewEnforcer(shared_ptr<Model> m) {
-    return NewEnforcer(m, NULL);
+unique_ptr<Enforcer> Enforcer ::NewEnforcer(shared_ptr<Model> m) {
+    return move(NewEnforcer(m, NULL));
 }
 
 /**
@@ -226,8 +226,8 @@ shared_ptr<Enforcer> Enforcer :: NewEnforcer(shared_ptr<Model> m) {
  *
  * @param model_path the path of the model file.
  */
-shared_ptr<Enforcer> Enforcer :: NewEnforcer(string model_path) {
-    return NewEnforcer(model_path, "");
+unique_ptr<Enforcer> Enforcer ::NewEnforcer(string model_path) {
+    return move(NewEnforcer(model_path, ""));
 }
 
 /**
@@ -237,10 +237,10 @@ shared_ptr<Enforcer> Enforcer :: NewEnforcer(string model_path) {
  * @param policyFile the path of the policy file.
  * @param enableLog whether to enable Casbin's log.
  */
-shared_ptr<Enforcer> Enforcer :: NewEnforcer(string model_path, string policyFile, bool enableLog) {
-    shared_ptr<Enforcer> e = NewEnforcer(model_path, shared_ptr<FileAdapter>(FileAdapter :: NewAdapter(policyFile)));
+unique_ptr<Enforcer> Enforcer :: NewEnforcer(string model_path, string policyFile, bool enableLog) {
+    unique_ptr<Enforcer> e = NewEnforcer(model_path, shared_ptr<FileAdapter>(FileAdapter :: NewAdapter(policyFile)));
     // e.EnableLog(enableLog);
-    return e;
+    return move(e);
 }
 
 
@@ -444,16 +444,6 @@ bool Enforcer :: Enforce(Scope scope) {
     return this->EnforceWithMatcher("", scope);
 }
 
-// Enforce with three params, decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (sub, obj, act).
-bool Enforcer::Enforce(string sub, string obj, string act) {
-    return EnforceWithMatcher("", sub, obj, act);
-}
-
-// Enforce with four params, decides whether a "subject" can access a "object" with the operation "action" in the domain "dom", input parameters are usually: (sub, dom, obj,act).
-bool Enforcer::Enforce(string sub, string dom, string obj, string act) {
-    return EnforceWithMatcher("", sub, dom, obj, act);
-}
-
 // Enforce with a vector param,decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (sub, obj, act).
 bool Enforcer::Enforce(vector<string> params) {
     return this->EnforceWithMatcher("", params);
@@ -467,16 +457,6 @@ bool Enforcer::Enforce(unordered_map<string, string> params) {
 // EnforceWithMatcher use a custom matcher to decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (matcher, sub, obj, act), use model matcher by default when matcher is "".
 bool Enforcer :: EnforceWithMatcher(string matcher, Scope scope) {
     return this->enforce(matcher, scope);
-}
-
-// Enforce with three params, decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (sub, obj, act).
-bool Enforcer::EnforceWithMatcher(string matcher, string sub, string obj, string act) {
-    return this->EnforceWithMatcher(matcher, { sub,obj,act });
-}
-
-// Enforce with four params, decides whether a "subject" can access a "object" with the operation "action" in the domain "dom", input parameters are usually: (sub, dom, obj,act).
-bool Enforcer::EnforceWithMatcher(string matcher, string sub, string dom, string obj, string act) {
-    return this->EnforceWithMatcher(matcher, { sub,dom,obj,act });
 }
 
 // EnforceWithMatcher use a custom matcher to decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (matcher, sub, obj, act), use model matcher by default when matcher is "".

--- a/casbin/enforcer.cpp
+++ b/casbin/enforcer.cpp
@@ -162,8 +162,8 @@ bool Enforcer :: enforce(string matcher, Scope scope) {
 /**
  * Enforcer is the default constructor.
  */
-Enforcer* Enforcer :: NewEnforcer() {
-    Enforcer* e = new Enforcer;
+shared_ptr<Enforcer> Enforcer :: NewEnforcer() {
+    shared_ptr<Enforcer> e = shared_ptr<Enforcer>(new Enforcer());
     return e;
 }
 
@@ -173,8 +173,8 @@ Enforcer* Enforcer :: NewEnforcer() {
  * @param model_path the path of the model file.
  * @param policyFile the path of the policy file.
  */
-Enforcer* Enforcer :: NewEnforcer(string model_path, string policyFile) {
-    return NewEnforcer(model_path, FileAdapter :: NewAdapter(policyFile));
+shared_ptr<Enforcer> Enforcer :: NewEnforcer(string model_path, string policyFile) {
+    return NewEnforcer(model_path, shared_ptr<FileAdapter>(FileAdapter :: NewAdapter(policyFile)));
 }
 
 /**
@@ -183,8 +183,8 @@ Enforcer* Enforcer :: NewEnforcer(string model_path, string policyFile) {
  * @param model_path the path of the model file.
  * @param adapter the adapter.
  */
-Enforcer* Enforcer :: NewEnforcer(string model_path, Adapter* adapter) {
-    Enforcer* e = NewEnforcer(Model :: NewModelFromFile(model_path), adapter);
+shared_ptr<Enforcer> Enforcer :: NewEnforcer(string model_path, shared_ptr<Adapter> adapter) {
+    shared_ptr<Enforcer> e = NewEnforcer(shared_ptr<Model>(Model :: NewModelFromFile(model_path)), adapter);
     e->model_path = model_path;
     return e;
 }
@@ -195,8 +195,8 @@ Enforcer* Enforcer :: NewEnforcer(string model_path, Adapter* adapter) {
  * @param m the model.
  * @param adapter the adapter.
  */
-Enforcer* Enforcer :: NewEnforcer(Model* m, Adapter* adapter) {
-    Enforcer* e = new Enforcer;
+shared_ptr<Enforcer> Enforcer :: NewEnforcer(shared_ptr<Model> m, shared_ptr<Adapter> adapter) {
+    shared_ptr<Enforcer> e = shared_ptr<Enforcer>(new Enforcer());
     e->adapter = adapter;
     e->watcher = NULL;
 
@@ -217,7 +217,7 @@ Enforcer* Enforcer :: NewEnforcer(Model* m, Adapter* adapter) {
  *
  * @param m the model.
  */
-Enforcer* Enforcer :: NewEnforcer(Model* m) {
+shared_ptr<Enforcer> Enforcer :: NewEnforcer(shared_ptr<Model> m) {
     return NewEnforcer(m, NULL);
 }
 
@@ -226,7 +226,7 @@ Enforcer* Enforcer :: NewEnforcer(Model* m) {
  *
  * @param model_path the path of the model file.
  */
-Enforcer* Enforcer :: NewEnforcer(string model_path) {
+shared_ptr<Enforcer> Enforcer :: NewEnforcer(string model_path) {
     return NewEnforcer(model_path, "");
 }
 
@@ -237,8 +237,8 @@ Enforcer* Enforcer :: NewEnforcer(string model_path) {
  * @param policyFile the path of the policy file.
  * @param enableLog whether to enable Casbin's log.
  */
-Enforcer* Enforcer :: NewEnforcer(string model_path, string policyFile, bool enableLog) {
-    Enforcer* e = NewEnforcer(model_path, FileAdapter :: NewAdapter(policyFile));
+shared_ptr<Enforcer> Enforcer :: NewEnforcer(string model_path, string policyFile, bool enableLog) {
+    shared_ptr<Enforcer> e = NewEnforcer(model_path, shared_ptr<FileAdapter>(FileAdapter :: NewAdapter(policyFile)));
     // e.EnableLog(enableLog);
     return e;
 }
@@ -246,13 +246,13 @@ Enforcer* Enforcer :: NewEnforcer(string model_path, string policyFile, bool ena
 
 // InitWithFile initializes an enforcer with a model file and a policy file.
 void Enforcer :: InitWithFile(string model_path, string policyPath) {
-    Adapter* a = FileAdapter::NewAdapter(policyPath);
+    shared_ptr<Adapter> a = shared_ptr<FileAdapter>(FileAdapter::NewAdapter(policyPath));
     this->InitWithAdapter(model_path, a);
 }
 
 // InitWithAdapter initializes an enforcer with a database adapter.
-void Enforcer :: InitWithAdapter(string model_path, Adapter* adapter) {
-    Model* m = Model :: NewModelFromFile(model_path);
+void Enforcer :: InitWithAdapter(string model_path, shared_ptr<Adapter> adapter) {
+    shared_ptr<Model> m =shared_ptr<Model>(Model :: NewModelFromFile(model_path));
 
     this->InitWithModelAndAdapter(m, adapter);
 
@@ -260,7 +260,7 @@ void Enforcer :: InitWithAdapter(string model_path, Adapter* adapter) {
 }
 
 // InitWithModelAndAdapter initializes an enforcer with a model and a database adapter.
-void Enforcer :: InitWithModelAndAdapter(Model* m, Adapter* adapter) {
+void Enforcer :: InitWithModelAndAdapter(shared_ptr<Model> m, shared_ptr<Adapter> adapter) {
     this->adapter = adapter;
 
     this->model = m;
@@ -275,8 +275,8 @@ void Enforcer :: InitWithModelAndAdapter(Model* m, Adapter* adapter) {
 }
 
 void Enforcer :: Initialize() {
-    this->rm = DefaultRoleManager :: NewRoleManager(10);
-    this->eft = DefaultEffector :: NewDefaultEffector();
+    this->rm = shared_ptr<DefaultRoleManager>(DefaultRoleManager :: NewRoleManager(10));
+    this->eft = shared_ptr<DefaultEffector>(DefaultEffector :: NewDefaultEffector());
     this->watcher = NULL;
 
     this->enabled = true;
@@ -288,7 +288,7 @@ void Enforcer :: Initialize() {
 // LoadModel reloads the model from the model CONF file.
 // Because the policy is attached to a model, so the policy is invalidated and needs to be reloaded by calling LoadPolicy().
 void Enforcer :: LoadModel() {
-    this->model = Model :: NewModelFromFile(this->model_path);
+    this->model = shared_ptr<Model>(Model ::NewModelFromFile(this->model_path));
 
     this->model->PrintModel();
     this->func_map.LoadFunctionMap();
@@ -297,12 +297,12 @@ void Enforcer :: LoadModel() {
 }
 
 // GetModel gets the current model.
-Model* Enforcer :: GetModel() {
+shared_ptr<Model> Enforcer :: GetModel() {
     return this->model;
 }
 
 // SetModel sets the current model.
-void Enforcer :: SetModel(Model* m) {
+void Enforcer :: SetModel(shared_ptr<Model> m) {
     this->model = m;
     this->func_map.LoadFunctionMap();
 
@@ -310,17 +310,17 @@ void Enforcer :: SetModel(Model* m) {
 }
 
 // GetAdapter gets the current adapter.
-Adapter* Enforcer :: GetAdapter() {
+shared_ptr<Adapter> Enforcer::GetAdapter() {
     return this->adapter;
 }
 
 // SetAdapter sets the current adapter.
-void Enforcer :: SetAdapter(Adapter* adapter) {
+void Enforcer::SetAdapter(shared_ptr<Adapter> adapter) {
     this->adapter = adapter;
 }
 
 // SetWatcher sets the current watcher.
-void Enforcer :: SetWatcher(Watcher* watcher) {
+void Enforcer :: SetWatcher(shared_ptr<Watcher> watcher) {
     this->watcher = watcher;
     auto func = [&, this](string str) {
         this->LoadPolicy();
@@ -329,17 +329,17 @@ void Enforcer :: SetWatcher(Watcher* watcher) {
 }
 
 // GetRoleManager gets the current role manager.
-RoleManager* Enforcer :: GetRoleManager() {
+shared_ptr<RoleManager> Enforcer ::GetRoleManager() {
     return this->rm;
 }
 
 // SetRoleManager sets the current role manager.
-void Enforcer :: SetRoleManager(RoleManager* rm) {
+void Enforcer :: SetRoleManager(shared_ptr<RoleManager> rm) {
     this->rm = rm;
 }
 
 // SetEffector sets the current effector.
-void Enforcer :: SetEffector(Effector* eft) {
+void Enforcer :: SetEffector(shared_ptr<Effector> eft) {
     this->eft = eft;
 }
 
@@ -351,7 +351,7 @@ void Enforcer :: ClearPolicy() {
 // LoadPolicy reloads the policy from file/database.
 void Enforcer :: LoadPolicy() {
     this->model->ClearPolicy();
-    this->adapter->LoadPolicy(this->model);
+    this->adapter->LoadPolicy(this->model.get());
     this->model->PrintPolicy();
 
     if(this->auto_build_role_links) {
@@ -367,7 +367,7 @@ void Enforcer :: LoadFilteredPolicy(Filter filter) {
     FilteredAdapter* filteredAdapter;
 
     if (this->adapter->IsFiltered()) {
-        void* adapter = this->adapter;
+        void* adapter = this->adapter.get();
         filteredAdapter = (FilteredAdapter*)adapter;
     }
     else
@@ -390,12 +390,12 @@ void Enforcer :: SavePolicy() {
     if(this->IsFiltered())
         throw CasbinEnforcerException("cannot save a filtered policy");
 
-    this->adapter->SavePolicy(this->model);
+    this->adapter->SavePolicy(this->model.get());
 
     if(this->watcher != NULL){
-        if (IsInstanceOf<WatcherEx>(this->watcher)) {
-            void* watcher = this->watcher;
-            ((WatcherEx*)watcher)->UpdateForSavePolicy(this->model);
+        if (IsInstanceOf<WatcherEx>(this->watcher.get())) {
+            void* watcher = this->watcher.get();
+            ((WatcherEx*)watcher)->UpdateForSavePolicy(this->model.get());
         }
         else
             return this->watcher->Update();
@@ -431,12 +431,12 @@ void Enforcer :: EnableAutoBuildRoleLinks(bool auto_build_role_links) {
 void Enforcer :: BuildRoleLinks() {
     this->rm->Clear();
 
-    this->model->BuildRoleLinks(this->rm);
+    this->model->BuildRoleLinks(this->rm.get());
 }
 
 // BuildIncrementalRoleLinks provides incremental build the role inheritance relations.
 void Enforcer :: BuildIncrementalRoleLinks(policy_op op, string p_type, vector<vector<string>> rules) {
-    return this->model->BuildIncrementalRoleLinks(this->rm, op, "g", p_type, rules);
+    return this->model->BuildIncrementalRoleLinks(this->rm.get(), op, "g", p_type, rules);
 }
 
 // Enforce decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (sub, obj, act).

--- a/casbin/enforcer.h
+++ b/casbin/enforcer.h
@@ -50,40 +50,40 @@ class Enforcer : public IEnforcer{
         /**
          * Enforcer is the default constructor.
          */
-        static shared_ptr<Enforcer> NewEnforcer();
+        static unique_ptr<Enforcer> NewEnforcer();
         /**
          * Enforcer initializes an enforcer with a model file and a policy file.
          *
          * @param model_path the path of the model file.
          * @param policyFile the path of the policy file.
          */
-        static shared_ptr<Enforcer> NewEnforcer(string model_path, string policyFile);
+        static unique_ptr<Enforcer> NewEnforcer(string model_path, string policyFile);
         /**
          * Enforcer initializes an enforcer with a database adapter.
          *
          * @param model_path the path of the model file.
          * @param adapter the adapter.
          */
-        static shared_ptr<Enforcer> NewEnforcer(string model_path, shared_ptr<Adapter> adapter);
+        static unique_ptr<Enforcer> NewEnforcer(string model_path, shared_ptr<Adapter> adapter);
         /**
          * Enforcer initializes an enforcer with a model and a database adapter.
          *
          * @param m the model.
          * @param adapter the adapter.
          */
-        static shared_ptr<Enforcer> NewEnforcer(shared_ptr<Model> m, shared_ptr<Adapter> adapter);
+        static unique_ptr<Enforcer> NewEnforcer(shared_ptr<Model> m, shared_ptr<Adapter> adapter);
         /**
          * Enforcer initializes an enforcer with a model.
          *
          * @param m the model.
          */
-        static shared_ptr<Enforcer> NewEnforcer(shared_ptr<Model> m);
+        static unique_ptr<Enforcer> NewEnforcer(shared_ptr<Model> m);
         /**
          * Enforcer initializes an enforcer with a model file.
          *
          * @param model_path the path of the model file.
          */
-        static shared_ptr<Enforcer> NewEnforcer(string model_path);
+        static unique_ptr<Enforcer> NewEnforcer(string model_path);
         /**
          * Enforcer initializes an enforcer with a model file, a policy file and an enable log flag.
          *
@@ -91,7 +91,7 @@ class Enforcer : public IEnforcer{
          * @param policyFile the path of the policy file.
          * @param enableLog whether to enable Casbin's log.
          */
-        static shared_ptr<Enforcer> NewEnforcer(string model_path, string policyFile, bool enableLog);
+        static unique_ptr<Enforcer> NewEnforcer(string model_path, string policyFile, bool enableLog);
         // InitWithFile initializes an enforcer with a model file and a policy file.
         void InitWithFile(string model_path, string policyPath);
         // InitWithAdapter initializes an enforcer with a database adapter.
@@ -148,20 +148,12 @@ class Enforcer : public IEnforcer{
         void BuildIncrementalRoleLinks(policy_op op, string p_type, vector<vector<string>> rules);
         // Enforce decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (sub, obj, act).
         bool Enforce(Scope scope);
-        // Enforce with three params, decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (sub, obj, act).
-        bool Enforce(string sub, string obj, string act);
-        // Enforce with four params, decides whether a "subject" can access a "object" with the operation "action" in the domain "dom", input parameters are usually: (sub, dom, obj,act).
-        bool Enforce(string sub, string dom, string obj, string act);
         // Enforce with a vector param,decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (sub, obj, act).
         bool Enforce(vector<string> params);        
         // Enforce with a map param,decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (sub, obj, act).
         bool Enforce(unordered_map<string,string> params);
         // EnforceWithMatcher use a custom matcher to decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (matcher, sub, obj, act), use model matcher by default when matcher is "".
         bool EnforceWithMatcher(string matcher, Scope scope);
-        // Enforce with three params, decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (sub, obj, act).
-        bool EnforceWithMatcher(string matcher, string sub, string obj, string act);
-        // Enforce with four params, decides whether a "subject" can access a "object" with the operation "action" in the domain "dom", input parameters are usually: (sub, dom, obj,act).
-        bool EnforceWithMatcher(string matcher, string sub, string dom, string obj, string act);
         // EnforceWithMatcher use a custom matcher to decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (matcher, sub, obj, act), use model matcher by default when matcher is "".
         bool EnforceWithMatcher(string matcher, vector<string> params);
         // EnforceWithMatcher use a custom matcher to decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (matcher, sub, obj, act), use model matcher by default when matcher is "".

--- a/casbin/enforcer.h
+++ b/casbin/enforcer.h
@@ -17,6 +17,7 @@
 #ifndef CASBIN_CPP_ENFORCER
 #define CASBIN_CPP_ENFORCER
 
+#include<memory>
 #include "./rbac/role_manager.h"
 #include "./model/function.h"
 #include "./enforcer_interface.h"
@@ -27,12 +28,12 @@ class Enforcer : public IEnforcer{
     private:
 
         string model_path;
-        Model* model;
+        shared_ptr<Model> model;
         FunctionMap func_map;
-        Effector* eft;
+        shared_ptr<Effector> eft;
 
-        Adapter* adapter;
-        Watcher* watcher;
+        shared_ptr<Adapter> adapter;
+        shared_ptr<Watcher> watcher;
 
         bool enabled;
         bool auto_save;
@@ -44,45 +45,45 @@ class Enforcer : public IEnforcer{
 
     public:
 
-        RoleManager* rm;
+        shared_ptr<RoleManager> rm;
 
         /**
          * Enforcer is the default constructor.
          */
-        static Enforcer* NewEnforcer();
+        static shared_ptr<Enforcer> NewEnforcer();
         /**
          * Enforcer initializes an enforcer with a model file and a policy file.
          *
          * @param model_path the path of the model file.
          * @param policyFile the path of the policy file.
          */
-        static Enforcer* NewEnforcer(string model_path, string policyFile);
+        static shared_ptr<Enforcer> NewEnforcer(string model_path, string policyFile);
         /**
          * Enforcer initializes an enforcer with a database adapter.
          *
          * @param model_path the path of the model file.
          * @param adapter the adapter.
          */
-        static Enforcer* NewEnforcer(string model_path, Adapter* adapter);
+        static shared_ptr<Enforcer> NewEnforcer(string model_path, shared_ptr<Adapter> adapter);
         /**
          * Enforcer initializes an enforcer with a model and a database adapter.
          *
          * @param m the model.
          * @param adapter the adapter.
          */
-        static Enforcer* NewEnforcer(Model* m, Adapter* adapter);
+        static shared_ptr<Enforcer> NewEnforcer(shared_ptr<Model> m, shared_ptr<Adapter> adapter);
         /**
          * Enforcer initializes an enforcer with a model.
          *
          * @param m the model.
          */
-        static Enforcer* NewEnforcer(Model* m);
+        static shared_ptr<Enforcer> NewEnforcer(shared_ptr<Model> m);
         /**
          * Enforcer initializes an enforcer with a model file.
          *
          * @param model_path the path of the model file.
          */
-        static Enforcer* NewEnforcer(string model_path);
+        static shared_ptr<Enforcer> NewEnforcer(string model_path);
         /**
          * Enforcer initializes an enforcer with a model file, a policy file and an enable log flag.
          *
@@ -90,33 +91,33 @@ class Enforcer : public IEnforcer{
          * @param policyFile the path of the policy file.
          * @param enableLog whether to enable Casbin's log.
          */
-        static Enforcer* NewEnforcer(string model_path, string policyFile, bool enableLog);
+        static shared_ptr<Enforcer> NewEnforcer(string model_path, string policyFile, bool enableLog);
         // InitWithFile initializes an enforcer with a model file and a policy file.
         void InitWithFile(string model_path, string policyPath);
         // InitWithAdapter initializes an enforcer with a database adapter.
-        void InitWithAdapter(string model_path, Adapter* adapter);
+        void InitWithAdapter(string model_path, shared_ptr<Adapter> adapter);
         // InitWithModelAndAdapter initializes an enforcer with a model and a database adapter.
-        void InitWithModelAndAdapter(Model* m, Adapter* adapter);
+        void InitWithModelAndAdapter(shared_ptr<Model> m, shared_ptr<Adapter> adapter);
         void Initialize();
         // LoadModel reloads the model from the model CONF file.
         // Because the policy is attached to a model, so the policy is invalidated and needs to be reloaded by calling LoadPolicy().
         void LoadModel();
         // GetModel gets the current model.
-        Model* GetModel();
+        shared_ptr<Model> GetModel();
         // SetModel sets the current model.
-        void SetModel(Model* m);
+        void SetModel(shared_ptr<Model> m);
         // GetAdapter gets the current adapter.
-        Adapter* GetAdapter();
+        shared_ptr<Adapter> GetAdapter();
         // SetAdapter sets the current adapter.
-        void SetAdapter(Adapter* adapter);
+        void SetAdapter(shared_ptr<Adapter> adapter);
         // SetWatcher sets the current watcher.
-        void SetWatcher(Watcher* watcher);
+        void SetWatcher(shared_ptr<Watcher> watcher);
         // GetRoleManager gets the current role manager.
-        RoleManager* GetRoleManager();
+        shared_ptr<RoleManager> GetRoleManager();
         // SetRoleManager sets the current role manager.
-        void SetRoleManager(RoleManager* rm);
+        void SetRoleManager(shared_ptr <RoleManager> rm);
         // SetEffector sets the current effector.
-        void SetEffector(Effector* eft);
+        void SetEffector(shared_ptr<Effector> eft);
         // ClearPolicy clears all policy.
         void ClearPolicy();
         // LoadPolicy reloads the policy from file/database.

--- a/casbin/enforcer_interface.h
+++ b/casbin/enforcer_interface.h
@@ -29,18 +29,18 @@ class IEnforcer {
 
         /* Enforcer API */
         virtual void InitWithFile(string modelPath, string policyPath) = 0;
-        virtual void InitWithAdapter(string modelPath, Adapter* adapter) = 0;
-        virtual void InitWithModelAndAdapter(Model* m, Adapter* adapter) = 0;
+        virtual void InitWithAdapter(string modelPath, shared_ptr<Adapter> adapter) = 0;
+        virtual void InitWithModelAndAdapter(shared_ptr<Model> m, shared_ptr<Adapter> adapter) = 0;
         virtual void Initialize() = 0;
         virtual void LoadModel() = 0;
-        virtual Model* GetModel() = 0;
-        virtual void SetModel(Model* m) = 0;
-        virtual Adapter* GetAdapter() = 0;
-        virtual void SetAdapter(Adapter* adapter) = 0;
-        virtual void SetWatcher(Watcher* watcher) = 0;
-        virtual RoleManager* GetRoleManager() = 0;
-        virtual void SetRoleManager(RoleManager* rm) = 0;
-        virtual void SetEffector(Effector* eft) = 0;
+        virtual shared_ptr<Model> GetModel() = 0;
+        virtual void SetModel(shared_ptr<Model> m) = 0;
+        virtual shared_ptr<Adapter> GetAdapter() = 0;
+        virtual void SetAdapter(shared_ptr<Adapter> adapter) = 0;
+        virtual void SetWatcher(shared_ptr<Watcher> watcher) = 0;
+        virtual shared_ptr<RoleManager> GetRoleManager() = 0;
+        virtual void SetRoleManager(shared_ptr<RoleManager> rm) = 0;
+        virtual void SetEffector(shared_ptr<Effector> eft) = 0;
         virtual void ClearPolicy() = 0;
         virtual void LoadPolicy() = 0;
 

--- a/casbin/internal_api.cpp
+++ b/casbin/internal_api.cpp
@@ -35,7 +35,7 @@ bool Enforcer :: addPolicy(string sec, string p_type, vector<string> rule) {
         this->BuildIncrementalRoleLinks(policy_add, p_type, rules);
     }
 
-    if (this->adapter != NULL && this->auto_save) {
+    if (this->adapter && this->auto_save) {
         try {
             this->adapter->AddPolicy(sec, p_type, rule);
         }
@@ -43,9 +43,9 @@ bool Enforcer :: addPolicy(string sec, string p_type, vector<string> rule) {
         }
     }
 
-    if (this->watcher != NULL && this->auto_notify_watcher) {
-        if (IsInstanceOf<WatcherEx>(this->watcher)) {
-            void* watcher = this->watcher;
+    if (this->watcher && this->auto_notify_watcher) {
+        if (IsInstanceOf<WatcherEx>(this->watcher.get())) {
+            void* watcher = this->watcher.get();
             ((WatcherEx*)watcher)->UpdateForAddPolicy(rule);
         }
         else
@@ -64,15 +64,16 @@ bool Enforcer :: addPolicies(string sec, string p_type, vector<vector<string>> r
     if (sec == "g")
         this->BuildIncrementalRoleLinks(policy_add, p_type, rules);
 
-    if (this->adapter != NULL && this->auto_save) {
+
+    if (this->adapter && this->auto_save) {
         try {
-            dynamic_cast<BatchAdapter*>(this->adapter)->AddPolicies(sec, p_type, rules);
+            dynamic_cast<BatchAdapter*>(this->adapter.get())->AddPolicies(sec, p_type, rules);
         }
         catch(UnsupportedOperationException e) {
         }
     }
 
-    if (this->watcher != NULL && this->auto_notify_watcher)
+    if (this->watcher && this->auto_notify_watcher)
         this->watcher->Update();
 
     return rules_added;
@@ -89,7 +90,7 @@ bool Enforcer :: removePolicy(string sec, string p_type, vector<string> rule) {
         this->BuildIncrementalRoleLinks(policy_add, p_type, rules);
     }
     
-    if (this->adapter != NULL && this->auto_save) {
+    if (this->adapter && this->auto_save) {
         try {
             this->adapter->RemovePolicy(sec, p_type, rule);
         }
@@ -97,9 +98,9 @@ bool Enforcer :: removePolicy(string sec, string p_type, vector<string> rule) {
         }
     }
 
-    if(this->watcher !=NULL && this->auto_notify_watcher){
-        if (IsInstanceOf<WatcherEx>(this->watcher)) {
-            void* watcher = this->watcher;
+    if(this->watcher && this->auto_notify_watcher){
+        if (IsInstanceOf<WatcherEx>(this->watcher.get())) {
+            void* watcher = this->watcher.get();
             ((WatcherEx*)watcher)->UpdateForRemovePolicy(rule);
         }
         else
@@ -118,15 +119,15 @@ bool Enforcer :: removePolicies(string sec, string p_type, vector<vector<string>
     if (sec == "g")
         this->BuildIncrementalRoleLinks(policy_add, p_type, rules);
 
-    if (this->adapter != NULL && this->auto_save) {
+    if (this->adapter && this->auto_save) {
         try{
-            dynamic_cast<BatchAdapter*>(this->adapter)->RemovePolicies(sec, p_type, rules);
+            dynamic_cast<BatchAdapter*>(this->adapter.get())->RemovePolicies(sec, p_type, rules);
         }
         catch(UnsupportedOperationException e){
         }
     }
 
-    if (this->watcher != NULL && this->auto_notify_watcher)
+    if (this->watcher && this->auto_notify_watcher)
         this->watcher->Update();
 
     return rules_removed;
@@ -144,7 +145,7 @@ bool Enforcer :: removeFilteredPolicy(string sec, string p_type, int field_index
     if (sec == "g")
         this->BuildIncrementalRoleLinks(policy_remove, p_type, effects);
 
-    if (this->adapter != NULL && this->auto_save) {
+    if (this->adapter && this->auto_save) {
         try {
             this->adapter->RemoveFilteredPolicy(sec, p_type, field_index, field_values); \
         }
@@ -152,9 +153,9 @@ bool Enforcer :: removeFilteredPolicy(string sec, string p_type, int field_index
         }
     }
 
-    if (this->watcher !=NULL && this->auto_notify_watcher) {
-        if (IsInstanceOf<WatcherEx>(this->watcher)) {
-            void* watcher = this->watcher;
+    if (this->watcher && this->auto_notify_watcher) {
+        if (IsInstanceOf<WatcherEx>(this->watcher.get())) {
+            void* watcher = this->watcher.get();
             ((WatcherEx*)watcher)->UpdateForRemoveFilteredPolicy(field_index, field_values);
         }
         else

--- a/test/test_enforcer.cpp
+++ b/test/test_enforcer.cpp
@@ -15,27 +15,28 @@ namespace test_enforcer
     {
     public:
 
-        void TestEnforce(Enforcer* e, string sub, string dom, string obj, string act, bool res) {
+        void TestEnforce(shared_ptr<Enforcer> e, string sub, string dom, string obj, string act, bool res) {
             Assert::AreEqual(res, e->Enforce(sub, dom, obj, act));
         }
 
-        void TestEnforce(Enforcer* e, string sub, string obj, string act, bool res) {
+        void TestEnforce(shared_ptr<Enforcer> e, string sub, string obj, string act, bool res) {
             Assert::AreEqual(res, e->Enforce(sub, obj, act));
         }
 
-        void TestEnforce(Enforcer* e, vector<string> params, bool res) {
+        void TestEnforce(shared_ptr<Enforcer> e, vector<string> params, bool res) {
             Assert::AreEqual(res, e->Enforce(params));
         }
 
-        void TestEnforce(Enforcer* e, unordered_map<string,string> params, bool res) {
+        void TestEnforce(shared_ptr<Enforcer> e, unordered_map<string,string> params, bool res) {
             Assert::AreEqual(res, e->Enforce(params));
         }
 
 
         TEST_METHOD(TestFourParams) {
+
             string model = "../../examples/rbac_with_domains_model.conf";
             string policy = "../../examples/rbac_with_domains_policy.csv";
-            Enforcer* e = Enforcer::NewEnforcer(model, policy);
+            shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
             TestEnforce(e, "alice", "domain1", "data1", "read", true);
             TestEnforce(e, "alice", "domain1", "data1", "write", true);
@@ -50,7 +51,7 @@ namespace test_enforcer
         TEST_METHOD(TestThreeParams) {
             string model = "../../examples/basic_model_without_spaces.conf";
             string policy = "../../examples/basic_policy.csv";
-            Enforcer* e = Enforcer::NewEnforcer(model, policy);
+            shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
             TestEnforce(e, { "alice", "data1", "read" }, true);
             TestEnforce(e, { "alice", "data1", "write" }, false);
@@ -65,7 +66,7 @@ namespace test_enforcer
         TEST_METHOD(TestVectorParams) {
             string model = "../../examples/basic_model_without_spaces.conf";
             string policy = "../../examples/basic_policy.csv";
-            Enforcer* e = Enforcer::NewEnforcer(model, policy);
+            shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
             TestEnforce(e, { "alice", "data1", "read" }, true);
             TestEnforce(e, { "alice", "data1", "write" }, false);
@@ -80,7 +81,7 @@ namespace test_enforcer
         TEST_METHOD(TestMapParams) {
             string model = "../../examples/basic_model_without_spaces.conf";
             string policy = "../../examples/basic_policy.csv";
-            Enforcer* e = Enforcer::NewEnforcer(model, policy);
+            shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
             unordered_map<string, string> params = { {"sub","alice"},{"obj","data1"},{"act","read"} };
             TestEnforce(e, params, true);

--- a/test/test_enforcer.cpp
+++ b/test/test_enforcer.cpp
@@ -15,19 +15,19 @@ namespace test_enforcer
     {
     public:
 
-        void TestEnforce(shared_ptr<Enforcer> e, string sub, string dom, string obj, string act, bool res) {
-            Assert::AreEqual(res, e->Enforce(sub, dom, obj, act));
+        void TestEnforce(unique_ptr<Enforcer>& e, string sub, string dom, string obj, string act, bool res) {
+            Assert::AreEqual(res, e->Enforce({sub, dom, obj, act}));
         }
 
-        void TestEnforce(shared_ptr<Enforcer> e, string sub, string obj, string act, bool res) {
-            Assert::AreEqual(res, e->Enforce(sub, obj, act));
+        void TestEnforce(unique_ptr<Enforcer>& e, string sub, string obj, string act, bool res) {
+            Assert::AreEqual(res, e->Enforce({sub, obj, act}));
         }
 
-        void TestEnforce(shared_ptr<Enforcer> e, vector<string> params, bool res) {
+        void TestEnforce(unique_ptr<Enforcer>& e, vector<string> params, bool res) {
             Assert::AreEqual(res, e->Enforce(params));
         }
 
-        void TestEnforce(shared_ptr<Enforcer> e, unordered_map<string,string> params, bool res) {
+        void TestEnforce(unique_ptr<Enforcer>& e, unordered_map<string,string> params, bool res) {
             Assert::AreEqual(res, e->Enforce(params));
         }
 
@@ -36,7 +36,7 @@ namespace test_enforcer
 
             string model = "../../examples/rbac_with_domains_model.conf";
             string policy = "../../examples/rbac_with_domains_policy.csv";
-            shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
+            unique_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
             TestEnforce(e, "alice", "domain1", "data1", "read", true);
             TestEnforce(e, "alice", "domain1", "data1", "write", true);
@@ -51,7 +51,7 @@ namespace test_enforcer
         TEST_METHOD(TestThreeParams) {
             string model = "../../examples/basic_model_without_spaces.conf";
             string policy = "../../examples/basic_policy.csv";
-            shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
+            unique_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
             TestEnforce(e, { "alice", "data1", "read" }, true);
             TestEnforce(e, { "alice", "data1", "write" }, false);
@@ -66,7 +66,7 @@ namespace test_enforcer
         TEST_METHOD(TestVectorParams) {
             string model = "../../examples/basic_model_without_spaces.conf";
             string policy = "../../examples/basic_policy.csv";
-            shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
+            unique_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
             TestEnforce(e, { "alice", "data1", "read" }, true);
             TestEnforce(e, { "alice", "data1", "write" }, false);
@@ -81,7 +81,7 @@ namespace test_enforcer
         TEST_METHOD(TestMapParams) {
             string model = "../../examples/basic_model_without_spaces.conf";
             string policy = "../../examples/basic_policy.csv";
-            shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
+            unique_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
             unordered_map<string, string> params = { {"sub","alice"},{"obj","data1"},{"act","read"} };
             TestEnforce(e, params, true);

--- a/test/test_management_api.cpp
+++ b/test/test_management_api.cpp
@@ -19,7 +19,7 @@ namespace test_management_api
             TEST_METHOD(TestGetList) {
                 string model = "../../examples/rbac_model.conf";
                 string policy = "../../examples/rbac_policy.csv";
-                Enforcer* e = Enforcer :: NewEnforcer(model, policy);
+                shared_ptr<Enforcer> e = Enforcer :: NewEnforcer(model, policy);
 
                 Assert::IsTrue(ArrayEquals(vector<string>{ "alice", "bob", "data2_admin" }, e->GetAllSubjects()));
                 Assert::IsTrue(ArrayEquals(vector<string>{ "data1", "data2" }, e->GetAllObjects()));
@@ -27,7 +27,7 @@ namespace test_management_api
                 Assert::IsTrue(ArrayEquals(vector<string>{ "data2_admin" }, e->GetAllRoles()));
             }
 
-            void TestGetPolicy(Enforcer* e, vector<vector<string>> res) {
+            void TestGetPolicy(shared_ptr<Enforcer> e, vector<vector<string>> res) {
                 vector<vector<string>> my_res;
                 my_res = e->GetPolicy();
 
@@ -43,14 +43,14 @@ namespace test_management_api
                     Assert::IsTrue(true);
             }
 
-            void TestGetFilteredPolicy(Enforcer* e, int field_index, vector<vector<string>> res, vector<string> field_values) {
+            void TestGetFilteredPolicy(shared_ptr<Enforcer> e, int field_index, vector<vector<string>> res, vector<string> field_values) {
                 vector<vector<string>> my_res = e->GetFilteredPolicy(field_index, field_values);
                 for (int i = 0; i < res.size(); i++) {
                     Assert::IsTrue(ArrayEquals(my_res[i], res[i]));
                 }
             }
 
-            void TestGetGroupingPolicy(Enforcer* e, vector<vector<string>> res) {
+            void TestGetGroupingPolicy(shared_ptr<Enforcer> e, vector<vector<string>> res) {
                 vector<vector<string>> my_res = e->GetGroupingPolicy();
 
                 for (int i = 0; i < my_res.size(); i++) {
@@ -58,7 +58,7 @@ namespace test_management_api
                 }
             }
 
-            void TestGetFilteredGroupingPolicy(Enforcer* e, int field_index, vector<vector<string>> res, vector<string> field_values) {
+            void TestGetFilteredGroupingPolicy(shared_ptr<Enforcer> e, int field_index, vector<vector<string>> res, vector<string> field_values) {
                 vector<vector<string>> my_res = e->GetFilteredGroupingPolicy(field_index, field_values);
 
                 for (int i = 0; i < my_res.size(); i++) {
@@ -66,12 +66,12 @@ namespace test_management_api
                 }
             }
 
-            void TestHasPolicy(Enforcer* e, vector<string> policy, bool res) {
+            void TestHasPolicy(shared_ptr<Enforcer> e, vector<string> policy, bool res) {
                 bool my_res = e->HasPolicy(policy);
                 Assert::AreEqual(res, my_res);
             }
 
-            void TestHasGroupingPolicy(Enforcer* e, vector<string> policy, bool res) {
+            void TestHasGroupingPolicy(shared_ptr<Enforcer> e, vector<string> policy, bool res) {
                 bool my_res = e->HasGroupingPolicy(policy);
                 Assert::AreEqual(res, my_res);
             }
@@ -79,7 +79,7 @@ namespace test_management_api
             TEST_METHOD(TestGetPolicyAPI) {
                 string model = "../../examples/rbac_model.conf";
                 string policy = "../../examples/rbac_policy.csv";
-                Enforcer* e = Enforcer::NewEnforcer(model, policy);
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 TestGetPolicy(e, vector<vector<string>>{
                     {"alice", "data1", "read"},
@@ -122,8 +122,8 @@ namespace test_management_api
             TEST_METHOD(TestModifyPolicyAPI) {
                 string model = "../../examples/rbac_model.conf";
                 string policy = "../../examples/rbac_policy.csv";
-                Adapter* adapter = BatchFileAdapter::NewAdapter(policy);
-                Enforcer* e = Enforcer::NewEnforcer(model, adapter);
+                shared_ptr<Adapter> adapter = shared_ptr<Adapter>(BatchFileAdapter::NewAdapter(policy));
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, adapter);
 
                 TestGetPolicy(e, vector<vector<string>>{
                     {"alice", "data1", "read"},
@@ -176,8 +176,8 @@ namespace test_management_api
             TEST_METHOD(TestModifyGroupingPolicyAPI) {
                 string model = "../../examples/rbac_model.conf";
                 string policy = "../../examples/rbac_policy.csv";
-                Adapter* adapter = BatchFileAdapter::NewAdapter(policy);
-                Enforcer* e = Enforcer::NewEnforcer(model, adapter);
+                shared_ptr<Adapter> adapter = shared_ptr<Adapter>(BatchFileAdapter::NewAdapter(policy));
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, adapter);
 
                 Assert::IsTrue(ArrayEquals(vector<string>{"data2_admin"}, e->GetRolesForUser("alice")));
                 Assert::IsTrue(ArrayEquals(vector<string>{}, e->GetRolesForUser("bob")));

--- a/test/test_model_enforcer.cpp
+++ b/test/test_model_enforcer.cpp
@@ -53,14 +53,14 @@ namespace test_model_enforcer
                 return scope;
             }
 
-            void TestEnforce(shared_ptr<Enforcer> e, Scope scope, bool res) {
+            void TestEnforce(unique_ptr<Enforcer>& e, Scope scope, bool res) {
                 Assert::AreEqual(res, e->Enforce(scope));
             }
 
             TEST_METHOD(TestBasicModel) {
                 string model = "../../examples/basic_model.conf";
                 string policy = "../../examples/basic_policy.csv";
-                shared_ptr<Enforcer> e = Enforcer ::NewEnforcer(model, policy);
+                unique_ptr<Enforcer> e = Enforcer ::NewEnforcer(model, policy);
 
                 Scope scope;
 
@@ -85,7 +85,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestBasicModelWithoutSpaces) {
                 string model = "../../examples/basic_model_without_spaces.conf";
                 string policy = "../../examples/basic_policy.csv";
-                shared_ptr<Enforcer> e = Enforcer ::NewEnforcer(model, policy);
+                unique_ptr<Enforcer> e = Enforcer ::NewEnforcer(model, policy);
 
                 Scope scope = InitializeParams("alice", "data1", "read");
                 TestEnforce(e, scope, true);
@@ -107,7 +107,7 @@ namespace test_model_enforcer
 
             TEST_METHOD(TestBasicModelNoPolicy) {
                 string model = "../../examples/basic_model.conf";
-                shared_ptr<Enforcer> e = Enforcer :: NewEnforcer(model);
+                unique_ptr<Enforcer> e = Enforcer :: NewEnforcer(model);
 
                 Scope scope = InitializeParams("alice", "data1", "read");
                 TestEnforce(e, scope, false);
@@ -130,7 +130,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestBasicModelWithRoot) {
                 string model = "../../examples/basic_with_root_model.conf";
                 string policy = "../../examples/basic_policy.csv";
-                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
+                unique_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 Scope scope = InitializeParams("alice", "data1", "read");
                 TestEnforce(e, scope, true);
@@ -160,7 +160,7 @@ namespace test_model_enforcer
 
             TEST_METHOD(TestBasicModelWithRootNoPolicy) {
                 string model = "../../examples/basic_with_root_model.conf";
-                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model);
+                unique_ptr<Enforcer> e = Enforcer::NewEnforcer(model);
 
                 Scope scope = InitializeParams("alice", "data1", "read");
                 TestEnforce(e, scope, false);
@@ -191,7 +191,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestBasicModelWithoutUsers) {
                 string model = "../../examples/basic_without_users_model.conf";
                 string policy = "../../examples/basic_without_users_policy.csv";
-                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
+                unique_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 Scope scope = InitializeParamsWithoutUsers("data1", "read");
                 TestEnforce(e, scope, true);
@@ -206,7 +206,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestBasicModelWithoutResources) {
                 string model = "../../examples/basic_without_resources_model.conf";
                 string policy = "../../examples/basic_without_resources_policy.csv";
-                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
+                unique_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 Scope scope = InitializeParamsWithoutResources("alice", "read");
                 TestEnforce(e, scope, true);
@@ -221,7 +221,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestRBACModel) {
                 string model = "../../examples/rbac_model.conf";
                 string policy = "../../examples/rbac_policy.csv";
-                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
+                unique_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 Scope scope = InitializeParams("alice", "data1", "read");
                 TestEnforce(e, scope, true);
@@ -244,7 +244,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestRBACModelWithResourceRoles) {
                 string model = "../../examples/rbac_with_resource_roles_model.conf";
                 string policy = "../../examples/rbac_with_resource_roles_policy.csv";
-                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
+                unique_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 Scope scope = InitializeParams("alice", "data1", "read");
                 TestEnforce(e, scope, true);
@@ -267,7 +267,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestRBACModelWithDomains) {
                 string model = "../../examples/rbac_with_domains_model.conf";
                 string policy = "../../examples/rbac_with_domains_policy.csv";
-                shared_ptr<Enforcer> e = Enforcer :: NewEnforcer(model, policy);
+                unique_ptr<Enforcer> e = Enforcer :: NewEnforcer(model, policy);
                 
                 Scope scope = InitializeParamsWithDomains("alice", "domain1", "data1", "read");
                 TestEnforce(e, scope, true);
@@ -289,7 +289,7 @@ namespace test_model_enforcer
             
             TEST_METHOD(TestRBACModelWithDomainsAtRuntime) {
                 string model = "../../examples/rbac_with_domains_model.conf";
-                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model);
+                unique_ptr<Enforcer> e = Enforcer::NewEnforcer(model);
 
                 vector<string> params{ "admin", "domain1", "data1", "read" };
                 e->AddPolicy(params);
@@ -369,7 +369,7 @@ namespace test_model_enforcer
                 string model = "../../examples/rbac_with_domains_model.conf";
                 string policy = "../../examples/rbac_with_domains_policy.csv";
                 shared_ptr<Adapter> adapter = shared_ptr<FileAdapter>(FileAdapter ::NewAdapter(policy));
-                shared_ptr<Enforcer> e = Enforcer :: NewEnforcer(model, adapter);
+                unique_ptr<Enforcer> e = Enforcer :: NewEnforcer(model, adapter);
 
                 vector<string> params{ "admin", "domain3", "data1", "read" };
                 e->AddPolicy(params);
@@ -397,7 +397,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestRBACModelWithDeny) {
                 string model = "../../examples/rbac_with_deny_model.conf";
                 string policy = "../../examples/rbac_with_deny_policy.csv";
-                shared_ptr<Enforcer> e = Enforcer :: NewEnforcer(model, policy);
+                unique_ptr<Enforcer> e = Enforcer :: NewEnforcer(model, policy);
 
                 Scope scope = InitializeParams("alice", "data1", "read");
                 TestEnforce(e, scope, true);
@@ -420,7 +420,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestRBACModelWithOnlyDeny) {
                 string model = "../../examples/rbac_with_not_deny_model.conf";
                 string policy = "../../examples/rbac_with_deny_policy.csv";
-                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
+                unique_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 Scope scope = InitializeParams("alice", "data2", "write");
                 TestEnforce(e, scope, false);
@@ -429,7 +429,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestRBACModelWithCustomData) {
                 string model = "../../examples/rbac_model.conf";
                 string policy = "../../examples/rbac_policy.csv";
-                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
+                unique_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 // You can add custom data to a grouping policy, Casbin will ignore it. It is only meaningful to the caller.
                 // This feature can be used to store information like whether "bob" is an end user (so no subject will inherit "bob")
@@ -481,7 +481,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestRBACModelWithPattern) {
                 string model = "../../examples/rbac_with_pattern_model.conf";
                 string policy = "../../examples/rbac_with_pattern_policy.csv";
-                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
+                unique_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 // Here's a little confusing: the matching function here is not the custom function used in matcher.
                 // It is the matching function used by "g" (and "g2", "g3" if any..)

--- a/test/test_model_enforcer.cpp
+++ b/test/test_model_enforcer.cpp
@@ -53,14 +53,14 @@ namespace test_model_enforcer
                 return scope;
             }
 
-            void TestEnforce(Enforcer* e, Scope scope, bool res) {
+            void TestEnforce(shared_ptr<Enforcer> e, Scope scope, bool res) {
                 Assert::AreEqual(res, e->Enforce(scope));
             }
 
             TEST_METHOD(TestBasicModel) {
                 string model = "../../examples/basic_model.conf";
                 string policy = "../../examples/basic_policy.csv";
-                Enforcer* e = Enforcer :: NewEnforcer(model, policy);
+                shared_ptr<Enforcer> e = Enforcer ::NewEnforcer(model, policy);
 
                 Scope scope;
 
@@ -85,7 +85,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestBasicModelWithoutSpaces) {
                 string model = "../../examples/basic_model_without_spaces.conf";
                 string policy = "../../examples/basic_policy.csv";
-                Enforcer* e = Enforcer :: NewEnforcer(model, policy);
+                shared_ptr<Enforcer> e = Enforcer ::NewEnforcer(model, policy);
 
                 Scope scope = InitializeParams("alice", "data1", "read");
                 TestEnforce(e, scope, true);
@@ -107,7 +107,7 @@ namespace test_model_enforcer
 
             TEST_METHOD(TestBasicModelNoPolicy) {
                 string model = "../../examples/basic_model.conf";
-                Enforcer* e = Enforcer :: NewEnforcer(model);
+                shared_ptr<Enforcer> e = Enforcer :: NewEnforcer(model);
 
                 Scope scope = InitializeParams("alice", "data1", "read");
                 TestEnforce(e, scope, false);
@@ -130,7 +130,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestBasicModelWithRoot) {
                 string model = "../../examples/basic_with_root_model.conf";
                 string policy = "../../examples/basic_policy.csv";
-                Enforcer* e = Enforcer::NewEnforcer(model, policy);
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 Scope scope = InitializeParams("alice", "data1", "read");
                 TestEnforce(e, scope, true);
@@ -160,7 +160,7 @@ namespace test_model_enforcer
 
             TEST_METHOD(TestBasicModelWithRootNoPolicy) {
                 string model = "../../examples/basic_with_root_model.conf";
-                Enforcer* e = Enforcer::NewEnforcer(model);
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model);
 
                 Scope scope = InitializeParams("alice", "data1", "read");
                 TestEnforce(e, scope, false);
@@ -191,7 +191,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestBasicModelWithoutUsers) {
                 string model = "../../examples/basic_without_users_model.conf";
                 string policy = "../../examples/basic_without_users_policy.csv";
-                Enforcer* e = Enforcer::NewEnforcer(model, policy);
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 Scope scope = InitializeParamsWithoutUsers("data1", "read");
                 TestEnforce(e, scope, true);
@@ -206,7 +206,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestBasicModelWithoutResources) {
                 string model = "../../examples/basic_without_resources_model.conf";
                 string policy = "../../examples/basic_without_resources_policy.csv";
-                Enforcer* e = Enforcer::NewEnforcer(model, policy);
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 Scope scope = InitializeParamsWithoutResources("alice", "read");
                 TestEnforce(e, scope, true);
@@ -221,7 +221,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestRBACModel) {
                 string model = "../../examples/rbac_model.conf";
                 string policy = "../../examples/rbac_policy.csv";
-                Enforcer* e = Enforcer::NewEnforcer(model, policy);
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 Scope scope = InitializeParams("alice", "data1", "read");
                 TestEnforce(e, scope, true);
@@ -244,7 +244,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestRBACModelWithResourceRoles) {
                 string model = "../../examples/rbac_with_resource_roles_model.conf";
                 string policy = "../../examples/rbac_with_resource_roles_policy.csv";
-                Enforcer* e = Enforcer::NewEnforcer(model, policy);
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 Scope scope = InitializeParams("alice", "data1", "read");
                 TestEnforce(e, scope, true);
@@ -267,7 +267,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestRBACModelWithDomains) {
                 string model = "../../examples/rbac_with_domains_model.conf";
                 string policy = "../../examples/rbac_with_domains_policy.csv";
-                Enforcer* e = Enforcer :: NewEnforcer(model, policy);
+                shared_ptr<Enforcer> e = Enforcer :: NewEnforcer(model, policy);
                 
                 Scope scope = InitializeParamsWithDomains("alice", "domain1", "data1", "read");
                 TestEnforce(e, scope, true);
@@ -289,7 +289,7 @@ namespace test_model_enforcer
             
             TEST_METHOD(TestRBACModelWithDomainsAtRuntime) {
                 string model = "../../examples/rbac_with_domains_model.conf";
-                Enforcer* e = Enforcer::NewEnforcer(model);
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model);
 
                 vector<string> params{ "admin", "domain1", "data1", "read" };
                 e->AddPolicy(params);
@@ -368,8 +368,8 @@ namespace test_model_enforcer
             TEST_METHOD(TestRBACModelWithDomainsAtRuntimeMockAdapter) {
                 string model = "../../examples/rbac_with_domains_model.conf";
                 string policy = "../../examples/rbac_with_domains_policy.csv";
-                Adapter* adapter = FileAdapter :: NewAdapter(policy);
-                Enforcer* e = Enforcer :: NewEnforcer(model, adapter);
+                shared_ptr<Adapter> adapter = shared_ptr<FileAdapter>(FileAdapter ::NewAdapter(policy));
+                shared_ptr<Enforcer> e = Enforcer :: NewEnforcer(model, adapter);
 
                 vector<string> params{ "admin", "domain3", "data1", "read" };
                 e->AddPolicy(params);
@@ -397,7 +397,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestRBACModelWithDeny) {
                 string model = "../../examples/rbac_with_deny_model.conf";
                 string policy = "../../examples/rbac_with_deny_policy.csv";
-                Enforcer* e = Enforcer :: NewEnforcer(model, policy);
+                shared_ptr<Enforcer> e = Enforcer :: NewEnforcer(model, policy);
 
                 Scope scope = InitializeParams("alice", "data1", "read");
                 TestEnforce(e, scope, true);
@@ -420,7 +420,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestRBACModelWithOnlyDeny) {
                 string model = "../../examples/rbac_with_not_deny_model.conf";
                 string policy = "../../examples/rbac_with_deny_policy.csv";
-                Enforcer* e = Enforcer::NewEnforcer(model, policy);
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 Scope scope = InitializeParams("alice", "data2", "write");
                 TestEnforce(e, scope, false);
@@ -429,7 +429,7 @@ namespace test_model_enforcer
             TEST_METHOD(TestRBACModelWithCustomData) {
                 string model = "../../examples/rbac_model.conf";
                 string policy = "../../examples/rbac_policy.csv";
-                Enforcer* e = Enforcer::NewEnforcer(model, policy);
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 // You can add custom data to a grouping policy, Casbin will ignore it. It is only meaningful to the caller.
                 // This feature can be used to store information like whether "bob" is an end user (so no subject will inherit "bob")
@@ -481,14 +481,14 @@ namespace test_model_enforcer
             TEST_METHOD(TestRBACModelWithPattern) {
                 string model = "../../examples/rbac_with_pattern_model.conf";
                 string policy = "../../examples/rbac_with_pattern_policy.csv";
-                Enforcer* e = Enforcer::NewEnforcer(model, policy);
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer(model, policy);
 
                 // Here's a little confusing: the matching function here is not the custom function used in matcher.
                 // It is the matching function used by "g" (and "g2", "g3" if any..)
                 // You can see in policy that: "g2, /book/:id, book_group", so in "g2()" function in the matcher, instead
                 // of checking whether "/book/:id" equals the obj: "/book/1", it checks whether the pattern matches.
                 // You can see it as normal RBAC: "/book/:id" == "/book/1" becomes KeyMatch2("/book/:id", "/book/1")
-                DefaultRoleManager* rm_tmp = (DefaultRoleManager*)e->rm;
+                DefaultRoleManager* rm_tmp = (DefaultRoleManager*)e->rm.get();
                 rm_tmp->AddMatchingFunc(KeyMatch2);
                 Scope scope = InitializeParams("alice", "/book/1", "GET");
                 TestEnforce(e, scope, true);

--- a/test/test_rbac_api.cpp
+++ b/test/test_rbac_api.cpp
@@ -15,7 +15,7 @@ namespace test_rbac_api
         public:
 
             TEST_METHOD(TestRoleAPI) {
-                Enforcer* e = Enforcer::NewEnforcer("../../examples/rbac_model.conf", "../../examples/rbac_policy.csv");
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_model.conf", "../../examples/rbac_policy.csv");
 
                 Assert::IsTrue(ArrayEquals(vector<string>{ "data2_admin" }, e->GetRolesForUser("alice")));
                 Assert::IsTrue(ArrayEquals(vector<string>{ }, e->GetRolesForUser("bob")));
@@ -74,7 +74,7 @@ namespace test_rbac_api
             }
 
             TEST_METHOD(TestEnforcer_AddRolesForUser) {
-                Enforcer* e = Enforcer::NewEnforcer("../../examples/rbac_model.conf", "../../examples/rbac_policy.csv");
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_model.conf", "../../examples/rbac_policy.csv");
 
                 e->AddRolesForUser("alice", vector<string>{ "data1_admin", "data2_admin", "data3_admin" });
                 Assert::IsTrue(ArrayEquals(vector<string>{ "data1_admin", "data2_admin", "data3_admin" }, e->GetRolesForUser("alice")));
@@ -84,7 +84,7 @@ namespace test_rbac_api
                 Assert::IsTrue(e->Enforce({ "alice", "data2", "write" }));
             }
 
-            void TestGetPermissions(Enforcer* e, string name, vector<vector<string>> res) {
+            void TestGetPermissions(shared_ptr<Enforcer> e, string name, vector<vector<string>> res) {
                 vector<vector<string>> my_res = e->GetPermissionsForUser(name);
 
                 int count = 0;
@@ -101,7 +101,7 @@ namespace test_rbac_api
             }
 
             TEST_METHOD(TestPermissionAPI) {
-                Enforcer* e = Enforcer::NewEnforcer("../../examples/basic_without_resources_model.conf", "../../examples/basic_without_resources_policy.csv");
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/basic_without_resources_model.conf", "../../examples/basic_without_resources_policy.csv");
 
                 Assert::IsTrue(e->Enforce(vector<string>{ "alice", "read" }));
                 Assert::IsFalse(e->Enforce(vector<string>{ "alice", "write" }));
@@ -146,7 +146,7 @@ namespace test_rbac_api
             }
 
             TEST_METHOD(TestImplicitRoleAPI) {
-                Enforcer* e = Enforcer::NewEnforcer("../../examples/rbac_model.conf", "../../examples/rbac_with_hierarchy_policy.csv");
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_model.conf", "../../examples/rbac_with_hierarchy_policy.csv");
 
                 TestGetPermissions(e, "alice", vector<vector<string>>{ {"alice", "data1", "read"} });
                 TestGetPermissions(e, "bob", vector<vector<string>>{ {"bob", "data2", "write"} });
@@ -156,13 +156,13 @@ namespace test_rbac_api
 
                 e = Enforcer::NewEnforcer("../../examples/rbac_with_pattern_model.conf", "../../examples/rbac_with_pattern_policy.csv");
 
-                dynamic_cast<DefaultRoleManager*>(e->GetRoleManager())->AddMatchingFunc(KeyMatch);
+                dynamic_cast<DefaultRoleManager*>(e->GetRoleManager().get())->AddMatchingFunc(KeyMatch);
 
                 Assert::IsTrue(ArrayEquals(vector<string>{ "/book/1/2/3/4/5", "pen_admin", "/book/*", "book_group" }, e->GetImplicitRolesForUser("cathy")));
                 Assert::IsTrue(ArrayEquals(vector<string>{ "/book/1/2/3/4/5", "pen_admin" }, e->GetRolesForUser("cathy")));
             }
 
-            void TestGetImplicitPermissions(Enforcer* e, string name, vector<vector<string>> res) {
+            void TestGetImplicitPermissions(shared_ptr<Enforcer> e, string name, vector<vector<string>> res) {
                 vector<vector<string>> my_res = e->GetImplicitPermissionsForUser(name);
 
                 int count = 0;
@@ -178,7 +178,7 @@ namespace test_rbac_api
                 Assert::AreEqual(int(res.size()), count);
             }
 
-            void TestGetImplicitPermissionsWithDomain(Enforcer* e, string name, string domain, vector<vector<string>> res) {
+            void TestGetImplicitPermissionsWithDomain(shared_ptr<Enforcer> e, string name, string domain, vector<vector<string>> res) {
                 vector<vector<string>> my_res = e->GetImplicitPermissionsForUser(name, { domain });
                 
                 int count = 0;
@@ -195,7 +195,7 @@ namespace test_rbac_api
             }
 
             TEST_METHOD(TestImplicitPermissionAPI) {
-                Enforcer* e = Enforcer::NewEnforcer("../../examples/rbac_model.conf", "../../examples/rbac_with_hierarchy_policy.csv");
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_model.conf", "../../examples/rbac_with_hierarchy_policy.csv");
 
                 TestGetPermissions(e, "alice", vector<vector<string>>{ {"alice", "data1", "read"} });
                 TestGetPermissions(e, "bob", vector<vector<string>>{ {"bob", "data2", "write"} });
@@ -205,12 +205,12 @@ namespace test_rbac_api
             }
 
             TEST_METHOD(TestImplicitPermissionAPIWithDomain) {
-                Enforcer* e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_hierarchy_with_domains_policy.csv");
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_hierarchy_with_domains_policy.csv");
                 TestGetImplicitPermissionsWithDomain(e, "alice", "domain1", vector<vector<string>>{ {"alice", "domain1", "data2", "read"}, { "role:reader", "domain1", "data1", "read" }, { "role:writer", "domain1", "data1", "write" } });
             }
 
             TEST_METHOD(TestImplicitUserAPI) {
-                Enforcer* e = Enforcer::NewEnforcer("../../examples/rbac_model.conf", "../../examples/rbac_with_hierarchy_policy.csv");
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_model.conf", "../../examples/rbac_with_hierarchy_policy.csv");
 
                 Assert::IsTrue(ArrayEquals(vector<string>{ "alice" }, e->GetImplicitUsersForPermission({ "data1", "read" })));
                 Assert::IsTrue(ArrayEquals(vector<string>{ "alice" }, e->GetImplicitUsersForPermission({ "data1", "write" })));

--- a/test/test_rbac_api_with_domains.cpp
+++ b/test/test_rbac_api_with_domains.cpp
@@ -16,7 +16,7 @@ namespace test_rbac_api_with_domains
         public:
 
             TEST_METHOD(TestGetImplicitRolesForDomainUser) {
-                shared_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_hierarchy_with_domains_policy.csv");
+                unique_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_hierarchy_with_domains_policy.csv");
 
                 // This is only able to retrieve the first level of roles.
                 Assert::IsTrue(ArrayEquals({ "role:global_admin" }, e->GetRolesForUserInDomain("alice", { "domain1" })));
@@ -27,7 +27,7 @@ namespace test_rbac_api_with_domains
 
             // TestUserAPIWithDomains: Add by Gordon
             TEST_METHOD(TestUserAPIWithDomains) {
-                shared_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_domains_policy.csv");
+                unique_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_domains_policy.csv");
 
                 Assert::IsTrue(ArrayEquals({ "alice" }, e->GetUsersForRole("admin", { "domain1" })));
                 Assert::IsTrue(ArrayEquals({ "alice" }, e->GetUsersForRoleInDomain("admin", { "domain1" })));
@@ -98,7 +98,7 @@ namespace test_rbac_api_with_domains
             }
 
             TEST_METHOD(TestRoleAPIWithDomains) {
-                shared_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_domains_policy.csv");
+                unique_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_domains_policy.csv");
                 
                 Assert::IsTrue(ArrayEquals({ "admin" }, e->GetRolesForUser("alice", { "domain1" })));
                 Assert::IsTrue(ArrayEquals({ "admin" }, e->GetRolesForUserInDomain("alice", { "domain1" })));
@@ -152,7 +152,7 @@ namespace test_rbac_api_with_domains
                 Assert::IsTrue(ArrayEquals({ }, e->GetRolesForUserInDomain("non_exist", { "domain2" })));
             }
 
-            void TestGetPermissionsInDomain(shared_ptr<Enforcer> e, string name, string domain, vector<vector<string>> res) {
+            void TestGetPermissionsInDomain(unique_ptr<Enforcer>& e, string name, string domain, vector<vector<string>> res) {
                 vector<vector<string>> my_res = e->GetPermissionsForUserInDomain(name, { domain });
 
                 int count = 0;
@@ -169,7 +169,7 @@ namespace test_rbac_api_with_domains
             }
 
             TEST_METHOD(TestPermissionAPIInDomain) {
-                shared_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_domains_policy.csv");
+                unique_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_domains_policy.csv");
 
                 TestGetPermissionsInDomain(e, "alice", "domain1", {});
                 TestGetPermissionsInDomain(e, "bob", "domain1", {});

--- a/test/test_rbac_api_with_domains.cpp
+++ b/test/test_rbac_api_with_domains.cpp
@@ -16,7 +16,7 @@ namespace test_rbac_api_with_domains
         public:
 
             TEST_METHOD(TestGetImplicitRolesForDomainUser) {
-                Enforcer* e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_hierarchy_with_domains_policy.csv");
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_hierarchy_with_domains_policy.csv");
 
                 // This is only able to retrieve the first level of roles.
                 Assert::IsTrue(ArrayEquals({ "role:global_admin" }, e->GetRolesForUserInDomain("alice", { "domain1" })));
@@ -27,7 +27,7 @@ namespace test_rbac_api_with_domains
 
             // TestUserAPIWithDomains: Add by Gordon
             TEST_METHOD(TestUserAPIWithDomains) {
-                Enforcer* e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_domains_policy.csv");
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_domains_policy.csv");
 
                 Assert::IsTrue(ArrayEquals({ "alice" }, e->GetUsersForRole("admin", { "domain1" })));
                 Assert::IsTrue(ArrayEquals({ "alice" }, e->GetUsersForRoleInDomain("admin", { "domain1" })));
@@ -98,7 +98,7 @@ namespace test_rbac_api_with_domains
             }
 
             TEST_METHOD(TestRoleAPIWithDomains) {
-                Enforcer* e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_domains_policy.csv");
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_domains_policy.csv");
                 
                 Assert::IsTrue(ArrayEquals({ "admin" }, e->GetRolesForUser("alice", { "domain1" })));
                 Assert::IsTrue(ArrayEquals({ "admin" }, e->GetRolesForUserInDomain("alice", { "domain1" })));
@@ -152,7 +152,7 @@ namespace test_rbac_api_with_domains
                 Assert::IsTrue(ArrayEquals({ }, e->GetRolesForUserInDomain("non_exist", { "domain2" })));
             }
 
-            void TestGetPermissionsInDomain(Enforcer* e, string name, string domain, vector<vector<string>> res) {
+            void TestGetPermissionsInDomain(shared_ptr<Enforcer> e, string name, string domain, vector<vector<string>> res) {
                 vector<vector<string>> my_res = e->GetPermissionsForUserInDomain(name, { domain });
 
                 int count = 0;
@@ -169,7 +169,7 @@ namespace test_rbac_api_with_domains
             }
 
             TEST_METHOD(TestPermissionAPIInDomain) {
-                Enforcer* e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_domains_policy.csv");
+                shared_ptr<Enforcer> e = Enforcer::NewEnforcer("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_domains_policy.csv");
 
                 TestGetPermissionsInDomain(e, "alice", "domain1", {});
                 TestGetPermissionsInDomain(e, "bob", "domain1", {});


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin-cpp/issues/55

Using smart pointers instead of raw pointer,to avoid the leak of memory.
``` Cpp
class Enforcer : public IEnforcer{
    private:

        string model_path;
        shared_ptr<Model> model;
        FunctionMap func_map;
        shared_ptr<Effector> eft;

        shared_ptr<Adapter> adapter;
        shared_ptr<Watcher> watcher;
...
```