### PR TITLE
feat: Replaced pragma with include guards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 mono_crash.*
 
 # Build results
+build
 [Dd]ebug/
 [Dd]ebugPublic/
 [Rr]elease/

--- a/casbin/config/config.cpp
+++ b/casbin/config/config.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef CONFIG_CPP
+#define CONFIG_CPP
+
 
 #include <fstream>
 #include <sstream>
@@ -181,3 +183,5 @@ string Config :: Get(string key) {
         return data[section][option];
     return "";
 }
+
+#endif // CONFIG_CPP

--- a/casbin/duktape/duktape.cpp
+++ b/casbin/duktape/duktape.cpp
@@ -151,9 +151,12 @@
 *  If you are accidentally missing from this list, send me an e-mail
 *  (``sami.vaarala@iki.fi``) and I'll fix the omission.
 */
-#pragma once
 
 #include "pch.h"
+
+#ifndef DUKTAPE_CPP
+#define DUKTAPE_CPP
+
 
 // #include "duk_config.h"
 
@@ -99759,3 +99762,5 @@ DUK_INTERNAL duk_double_t duk_util_tinyrandom_get_double(duk_hthread *thr) {
 #undef DUK__RANDOM_XOROSHIRO128PLUS
 #undef DUK__RND_BIT
 #undef DUK__UPDATE_RND
+
+#endif // DUKTAPE_CPP

--- a/casbin/effect/default_effector.cpp
+++ b/casbin/effect/default_effector.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef DEFAULT_EFFECTOR_CPP
+#define DEFAULT_EFFECTOR_CPP
+
 
 #include "./default_effector.h"
 #include "../exception/unsupported_operation_exception.h"
@@ -71,3 +73,5 @@ bool DefaultEffector :: MergeEffects(string expr, vector<Effect> effects, vector
 
     return result;
 }
+
+#endif // DEFAULT_EFFECTOR_CPP

--- a/casbin/enforcer.cpp
+++ b/casbin/enforcer.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef ENFORCER_CPP
+#define ENFORCER_CPP
+
 
 #include <algorithm>
 
@@ -485,3 +487,5 @@ bool Enforcer::EnforceWithMatcher(string matcher, unordered_map<string, string> 
     DeinitializeScope(scope);
     return result;
 }
+
+#endif // ENFORCER_CPP

--- a/casbin/enforcer_cached.cpp
+++ b/casbin/enforcer_cached.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef ENFORCER_CACHED_CPP
+#define ENFORCER_CACHED_CPP
+
 
 #include "./enforcer_cached.h"
 #include "./persist/watcher_ex.h"
@@ -211,3 +213,5 @@ bool CachedEnforcer::EnforceWithMatcher(string matcher, unordered_map<string, st
   setCachedResult(key, res);
   return res;
 }
+
+#endif // ENFORCER_CACHED_CPP

--- a/casbin/exception/casbin_adapter_exception.cpp
+++ b/casbin/exception/casbin_adapter_exception.cpp
@@ -1,9 +1,13 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef CASBIN_ADAPTER_EXCEPTION_CPP
+#define CASBIN_ADAPTER_EXCEPTION_CPP
+
 
 #include "./casbin_adapter_exception.h"
 
 CasbinAdapterException :: CasbinAdapterException(string error_message) {
     this->error_message = error_message;
 }
+
+#endif // CASBIN_ADAPTER_EXCEPTION_CPP

--- a/casbin/exception/casbin_enforcer_exception.cpp
+++ b/casbin/exception/casbin_enforcer_exception.cpp
@@ -1,9 +1,13 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef CASBIN_ENFORCER_EXCEPTION_CPP
+#define CASBIN_ENFORCER_EXCEPTION_CPP
+
 
 #include "./casbin_enforcer_exception.h"
 
 CasbinEnforcerException :: CasbinEnforcerException(string error_message){
     this->error_message = error_message;
 }
+
+#endif // CASBIN_ENFORCER_EXCEPTION_CPP

--- a/casbin/exception/casbin_rbac_exception.cpp
+++ b/casbin/exception/casbin_rbac_exception.cpp
@@ -1,9 +1,13 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef CASBIN_RBAC_EXCEPTION_CPP
+#define CASBIN_RBAC_EXCEPTION_CPP
+
 
 #include "./casbin_rbac_exception.h"
 
 CasbinRBACException :: CasbinRBACException(string error_message){
     this->error_message = error_message;
 }
+
+#endif // CASBIN_RBAC_EXCEPTION_CPP

--- a/casbin/exception/illegal_argument_exception.cpp
+++ b/casbin/exception/illegal_argument_exception.cpp
@@ -1,9 +1,13 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef ILLEGAL_ARGUMENT_EXCEPTION_CPP
+#define ILLEGAL_ARGUMENT_EXCEPTION_CPP
+
 
 #include "./illegal_argument_exception.h"
 
 IllegalArgumentException :: IllegalArgumentException(string error_message) {
     this->error_message = error_message;
 }
+
+#endif // ILLEGAL_ARGUMENT_EXCEPTION_CPP

--- a/casbin/exception/io_exception.cpp
+++ b/casbin/exception/io_exception.cpp
@@ -1,9 +1,13 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef IO_EXCEPTION
+#define IO_EXCEPTION
+
 
 #include "./io_exception.h"
 
 IOException :: IOException(string error_message) {
     this->error_message = error_message;
 }
+
+#endif //IO_EXCEPTION

--- a/casbin/exception/missing_required_sections.cpp
+++ b/casbin/exception/missing_required_sections.cpp
@@ -1,9 +1,13 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef MISSING_REQUIRED_SECTIONS_CPP
+#define MISSING_REQUIRED_SECTIONS_CPP
+
 
 #include "./missing_required_sections.h"
 
 MissingRequiredSections :: MissingRequiredSections(string error_message) {
     this->error_message = error_message;
 }
+
+#endif // MISSING_REQUIRED_SECTIONS_CPP

--- a/casbin/exception/unsupported_operation_exception.cpp
+++ b/casbin/exception/unsupported_operation_exception.cpp
@@ -1,9 +1,13 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef UNSUPPORTED_OPERATION_EXCEPTION_CPP
+#define UNSUPPORTED_OPERATION_EXCEPTION_CPP
+
 
 #include "./unsupported_operation_exception.h"
 
 UnsupportedOperationException :: UnsupportedOperationException(string error_message) {
     this->error_message = error_message;
 }
+
+#endif // UNSUPPORTED_OPERATION_EXCEPTION_CPP

--- a/casbin/internal_api.cpp
+++ b/casbin/internal_api.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef INTERNAL_API_CPP
+#define INTERNAL_API_CPP
+
 
 #include "./enforcer.h"
 #include "./persist/batch_adapter.h"
@@ -161,3 +163,5 @@ bool Enforcer :: removeFilteredPolicy(string sec, string p_type, int field_index
 
     return rule_removed;
 }
+
+#endif // INTERNAL_API_CPP

--- a/casbin/ip_parser/exception/parser_exception.cpp
+++ b/casbin/ip_parser/exception/parser_exception.cpp
@@ -1,9 +1,13 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef PARSER_EXCEPTION_CPP
+#define PARSER_EXCEPTION_CPP
+
 
 #include "./parser_exception.h"
 
 ParserException :: ParserException(string error_message){
     this->error_message = error_message;
 }
+
+#endif // PARSER_EXCEPTION_CPP

--- a/casbin/ip_parser/parser/CIDRMask.cpp
+++ b/casbin/ip_parser/parser/CIDRMask.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef CIDRMASK_CPP
+#define CIDRMASK_CPP
+
 
 #include "./CIDRMask.h"
 
@@ -27,3 +29,5 @@ IPMask CIDRMask(int ones, int bits) {
     }
     return mask;
 }
+
+#endif // CIDRMASK_CPP

--- a/casbin/ip_parser/parser/IP.cpp
+++ b/casbin/ip_parser/parser/IP.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef IP_CPP
+#define IP_CPP
+
 
 #include "./IP.h"
 
@@ -102,3 +104,5 @@ bool IP :: isZeros(IP p) {
     }
     return true;
 }
+
+#endif // IP_CPP

--- a/casbin/ip_parser/parser/IPNet.cpp
+++ b/casbin/ip_parser/parser/IPNet.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef IPNET_CPP
+#define IPNET_CPP
+
 
 #include "./IPNet.h"
 
@@ -84,3 +86,5 @@ pair<IP, IPMask> IPNet :: networkNumberAndMask(IPNet n) {
     }
     return p;
 }
+
+#endif // IPNET_CPP

--- a/casbin/ip_parser/parser/IPv4.cpp
+++ b/casbin/ip_parser/parser/IPv4.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef IPV4_CPP
+#define IPV4_CPP
+
 
 #include "./IPv4.h"
 
@@ -15,3 +17,5 @@ IP IPv4(byte a, byte b, byte c, byte d) {
     p.isLegal = true;
     return p;
 }
+
+#endif // IPV4_CPP

--- a/casbin/ip_parser/parser/Print.cpp
+++ b/casbin/ip_parser/parser/Print.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef PRINT_CPP
+#define PRINT_CPP
+
 
 #include "./Print.h"
 
@@ -11,3 +13,5 @@ void Print(IP ip_addr) {
     cout<<endl;
     cout<<"Status : "<<ip_addr.isLegal<<endl;
 }
+
+#endif // PRINT_CPP

--- a/casbin/ip_parser/parser/allFF.cpp
+++ b/casbin/ip_parser/parser/allFF.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef ALLFF_CPP
+#define ALLFF_CPP
+
 
 #include "./allFF.h"
 
@@ -12,3 +14,5 @@ bool allFF(vector<byte> b) {
     }
     return true;
 }
+
+#endif // ALLFF_CPP

--- a/casbin/ip_parser/parser/dtoi.cpp
+++ b/casbin/ip_parser/parser/dtoi.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef DTOI_CPP
+#define DTOI_CPP
+
 
 #include "./dtoi.h"
 
@@ -27,3 +29,5 @@ pair<int, int> dtoi(string s) {
     p.second = i;
     return p;
 }
+
+#endif // DTOI_CPP

--- a/casbin/ip_parser/parser/equal.cpp
+++ b/casbin/ip_parser/parser/equal.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef EQUAL_CPP
+#define EQUAL_CPP
+
 
 #include "./equal.h"
 
@@ -13,3 +15,5 @@ bool equal(IPMask m1, IPMask m2) {
     }
     return true;
 }
+
+#endif // EQUAL_CPP

--- a/casbin/ip_parser/parser/parseCIDR.cpp
+++ b/casbin/ip_parser/parser/parseCIDR.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef PARSECIDR_CPP
+#define PARSECIDR_CPP
+
 
 #include "./parseCIDR.h"
 
@@ -30,3 +32,5 @@ CIDR parseCIDR(string s) {
 
     return cidr_addr;
 }
+
+#endif // PARSECIDR_CPP

--- a/casbin/ip_parser/parser/parseIP.cpp
+++ b/casbin/ip_parser/parser/parseIP.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef PARSEIP_CPP
+#define PARSEIP_CPP
+
 
 #include "./parseIP.h"
 
@@ -17,3 +19,5 @@ IP parseIP(string s) {
     p.isLegal = false;
     return p;
 }
+
+#endif // PARSEIP_CPP

--- a/casbin/ip_parser/parser/parseIPv4.cpp
+++ b/casbin/ip_parser/parser/parseIPv4.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef PARSEIPV4_CPP
+#define PARSEIPV4_CPP
+
 
 #include "./parseIPv4.h"
 
@@ -34,3 +36,5 @@ IP parseIPv4(string s) {
     }
     return IPv4(pb[0], pb[1], pb[2], pb[3]);
 }
+
+#endif // PARSEIPV4_CPP

--- a/casbin/ip_parser/parser/parseIPv6.cpp
+++ b/casbin/ip_parser/parser/parseIPv6.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef PARSEIPV6_CPP
+#define PARSEIPV6_CPP
+
 
 #include "./parseIPv6.h"
 
@@ -113,3 +115,5 @@ IP parseIPv6(string s) {
     }
     return ipv6;
 }
+
+#endif // PARSEIPV6_CPP

--- a/casbin/ip_parser/parser/xtoi.cpp
+++ b/casbin/ip_parser/parser/xtoi.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef XTOI_CPP
+#define XTOI_CPP
+
 
 #include "./xtoi.h"
 
@@ -36,3 +38,5 @@ pair<int, int> xtoi(string s) {
     p.second = i;
     return p;
 }
+
+#endif // XTOI_CPP

--- a/casbin/management_api.cpp
+++ b/casbin/management_api.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef MANAGEMENT_API_CPP
+#define MANAGEMENT_API_CPP
+
 
 #include "./enforcer.h"
 
@@ -307,3 +309,5 @@ bool Enforcer :: RemoveFilteredNamedGroupingPolicy(string p_type, int field_inde
 void Enforcer :: AddFunction(string name, Function function, Index nargs) {
     user_func_list.push_back(make_tuple(name, function, nargs));
 }
+
+#endif // MANAGEMENT_API_CPP

--- a/casbin/model/assertion.cpp
+++ b/casbin/model/assertion.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef ASSERTION_CPP
+#define ASSERTION_CPP
+
 
 #include <algorithm>
 
@@ -79,3 +81,5 @@ void Assertion :: BuildRoleLinks(shared_ptr<RoleManager> rm) {
 
     // this->rm->PrintRoles();
 }
+
+#endif // ASSERTION_CPP

--- a/casbin/model/function.cpp
+++ b/casbin/model/function.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef FUNCTION_CPP
+#define FUNCTION_CPP
+
 
 #include "./function.h"
 #include "../util/util.h"
@@ -122,3 +124,5 @@ void FunctionMap :: LoadFunctionMap() {
     AddFunction("regexMatch", RegexMatch, 2);
     AddFunction("ipMatch", IPMatch, 2);
 }
+
+#endif // FUNCTION_CPP

--- a/casbin/model/model.cpp
+++ b/casbin/model/model.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef MODEL_CPP
+#define MODEL_CPP
+
 
 #include <sstream>
 
@@ -343,3 +345,5 @@ vector<string> Model :: GetValuesForFieldInPolicyAllTypes(string sec, int field_
 
     return values;
 }
+
+#endif // MODEL_CPP

--- a/casbin/model/scope_config.cpp
+++ b/casbin/model/scope_config.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef SCOPE_CONFIG_CPP
+#define SCOPE_CONFIG_CPP
+
 
 #include "./scope_config.h"
 
@@ -241,3 +243,5 @@ bool Eval(Scope scope, string expression){
 void EvalNoResult(Scope scope, string expression){
     duk_eval_string_noresult(scope, expression.c_str());
 }
+
+#endif // SCOPE_CONFIG_CPP

--- a/casbin/persist/adapter.cpp
+++ b/casbin/persist/adapter.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef ADAPTER_CPP
+#define ADAPTER_CPP
+
 
 #include "./adapter.h"
 #include "../util/util.h"
@@ -39,3 +41,5 @@ void LoadPolicyLine(string line, Model* model) {
 
     (model->m[sec].assertion_map[key]->policy).push_back(new_tokens);
 }
+
+#endif // ADAPTER_CPP

--- a/casbin/persist/default_watcher.cpp
+++ b/casbin/persist/default_watcher.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef DEFAULT_WATCHER_CPP
+#define DEFAULT_WATCHER_CPP
+
 
 #include "./default_watcher.h"
 
@@ -32,3 +34,5 @@ void DefaultWatcher :: Update() {
 void DefaultWatcher :: Close() {
     return;
 }
+
+#endif // DEFAULT_WATCHER_CPP

--- a/casbin/persist/default_watcher_ex.cpp
+++ b/casbin/persist/default_watcher_ex.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef DEFAULT_WATCHER_EX_CPP
+#define DEFAULT_WATCHER_EX_CPP
+
 
 #include "./default_watcher_ex.h"
 
@@ -35,3 +37,5 @@ void DefaultWatcherEx :: UpdateForRemoveFilteredPolicy(int field_index, vector<s
 void DefaultWatcherEx :: UpdateForSavePolicy(Model* model) {
     return;
 }
+
+#endif // DEFAULT_WATCHER_EX_CPP

--- a/casbin/persist/file_adapter/batch_file_adapter.cpp
+++ b/casbin/persist/file_adapter/batch_file_adapter.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef BATCH_FILE_ADAPTER_CPP
+#define BATCH_FILE_ADAPTER_CPP
+
 
 #include "./batch_file_adapter.h"
 #include "../../exception/unsupported_operation_exception.h"
@@ -16,3 +18,5 @@ void BatchFileAdapter :: AddPolicies(string sec, string p_type, vector<vector<st
 void BatchFileAdapter :: RemovePolicies(string sec, string p_type, vector<vector<string>> rules) {
     throw UnsupportedOperationException("not implemented");
 }
+
+#endif // BATCH_FILE_ADAPTER_CPP

--- a/casbin/persist/file_adapter/file_adapter.cpp
+++ b/casbin/persist/file_adapter/file_adapter.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef FILE_ADAPTER_CPP
+#define FILE_ADAPTER_CPP
+
 
 #include <fstream>
 
@@ -101,3 +103,5 @@ void FileAdapter :: RemoveFilteredPolicy(string sec, string p_type, int field_in
 bool FileAdapter :: IsFiltered() {
     return this->filtered;
 }
+
+#endif // FILE_ADAPTER_CPP

--- a/casbin/persist/file_adapter/filtered_file_adapter.cpp
+++ b/casbin/persist/file_adapter/filtered_file_adapter.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef FILTERED_FILE_ADAPTER_CPP
+#define FILTERED_FILE_ADAPTER_CPP
+
 
 #include <fstream>
 
@@ -102,3 +104,5 @@ void FilteredFileAdapter :: SavePolicy(Model* model) {
     }
     this->SavePolicy(model);
 }
+
+#endif // FILTERED_FILE_ADAPTER_CPP

--- a/casbin/rbac/default_role_manager.cpp
+++ b/casbin/rbac/default_role_manager.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef DEFAULT_ROLE_MANAGER_CPP
+#define DEFAULT_ROLE_MANAGER_CPP
+
 
 #include "./default_role_manager.h"
 #include "../exception/casbin_rbac_exception.h"
@@ -287,3 +289,5 @@ void DefaultRoleManager :: PrintRoles() {
         text += ", " + it->second->ToString();
     // LogUtil::LogPrint(text);
 }
+
+#endif // DEFAULT_ROLE_MANAGER_CPP

--- a/casbin/rbac_api.cpp
+++ b/casbin/rbac_api.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef RBAC_API_CPP
+#define RBAC_API_CPP
+
 
 #include "./enforcer.h"
 #include "./exception/casbin_enforcer_exception.h"
@@ -242,3 +244,5 @@ vector<string> Enforcer :: GetImplicitUsersForPermission(vector<string> permissi
     res = SetSubtract(res, g_inherit);
     return res;
 }
+
+#endif // RBAC_API_CPP

--- a/casbin/rbac_api_with_domains.cpp
+++ b/casbin/rbac_api_with_domains.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef RBAC_API_WITH_DOMAINS_CPP
+#define RBAC_API_WITH_DOMAINS_CPP
+
 
 #include "./enforcer.h"
 
@@ -53,3 +55,5 @@ bool Enforcer :: DeleteRoleForUserInDomain(string user, string role, string doma
     vector<string> params{user, role, domain};
 	return this->RemoveGroupingPolicy(params);
 }
+
+#endif // RBAC_API_WITH_DOMAINS_CPP

--- a/casbin/util/array_equals.cpp
+++ b/casbin/util/array_equals.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef ARRAY_EQUALS_CPP
+#define ARRAY_EQUALS_CPP
+
 
 #include <algorithm>
 
@@ -39,3 +41,5 @@ bool ArrayEquals(vector<string> a, vector<string> b) {
     }
     return true;
 }
+
+#endif // ARRAY_EQUALS_CPP

--- a/casbin/util/array_remove_duplicates.cpp
+++ b/casbin/util/array_remove_duplicates.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef ARRAY_REMOVE_DUPLICATES_CPP
+#define ARRAY_REMOVE_DUPLICATES_CPP
+
 
 #include <unordered_map>
 
@@ -37,3 +39,5 @@ void ArrayRemoveDuplicates(vector<string> &s) {
     }
     s = vector<string> (s.begin(), s.begin()+j);
 }
+
+#endif // ARRAY_REMOVE_DUPLICATES_CPP

--- a/casbin/util/array_to_string.cpp
+++ b/casbin/util/array_to_string.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef ARRAY_TO_STRING_CPP
+#define ARRAY_TO_STRING_CPP
+
 
 #include "./util.h"
 
@@ -28,3 +30,5 @@ string ArrayToString(vector<string> arr){
         res += ", " + arr[i];
     return res;
 }
+
+#endif // ARRAY_TO_STRING_CPP

--- a/casbin/util/built_in_functions.cpp
+++ b/casbin/util/built_in_functions.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef BUILT_IN_FUNCTIONS_CPP
+#define BUILT_IN_FUNCTIONS_CPP
+
 
 #include <regex>
 
@@ -227,3 +229,5 @@ ReturnType GFunction(Scope scope) {
 
     return RETURN_RESULT;
 }
+
+#endif // BUILT_IN_FUNCTIONS_CPP

--- a/casbin/util/ends_with.cpp
+++ b/casbin/util/ends_with.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef ENDS_WITH_CPP
+#define ENDS_WITH_CPP
+
 
 #include "./util.h"
 
@@ -27,3 +29,5 @@ bool EndsWith(string base, string suffix){
     int suffix_len = int(suffix.length());
     return base.substr(base_len-suffix_len, suffix_len).compare(suffix) == 0;
 }
+
+#endif // ENDS_WITH_CPP

--- a/casbin/util/escape_assertion.cpp
+++ b/casbin/util/escape_assertion.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef ESCAPE_ASSERTION_CPP
+#define ESCAPE_ASSERTION_CPP
+
 
 #include <regex>
 
@@ -48,3 +50,5 @@ string EscapeAssertion(string s) {
 
     return s;
 }
+
+#endif // ESCAPE_ASSERTION_CPP

--- a/casbin/util/find_all_occurences.cpp
+++ b/casbin/util/find_all_occurences.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef FIND_ADD_OCCURENCES_CPP
+#define FIND_ADD_OCCURENCES_CPP
+
 
 #include "./util.h"
 
@@ -38,3 +40,5 @@ vector <size_t> FindAllOccurences(string data, string toSearch){
     }
     return vec;
 }
+
+#endif // FIND_ADD_OCCURENCES_CPP

--- a/casbin/util/is_instance_of.cpp
+++ b/casbin/util/is_instance_of.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef IS_INSTANCE_OF_CPP
+#define IS_INSTANCE_OF_CPP
+
 
 #include "./util.h"
 #include "../persist/watcher_ex.h"
@@ -29,3 +31,5 @@ bool IsInstanceOf(const T*) {
 }
 
 template bool IsInstanceOf<class WatcherEx, class Watcher>(class Watcher const*);
+
+#endif //IS_INSTANCE_OF_CPP

--- a/casbin/util/join.cpp
+++ b/casbin/util/join.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef JOIN_CPP
+#define JOIN_CPP
+
 
 #include "./util.h"
 
@@ -28,3 +30,5 @@ string Join(vector<string> vos, string sep){
         fs += sep + vos[i];
     return fs;
 }
+
+#endif // JOIN_CPP

--- a/casbin/util/join_slice.cpp
+++ b/casbin/util/join_slice.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef JOIN_SLICE_CPP
+#define JOIN_SLICE_CPP
+
 
 #include "./util.h"
 
@@ -28,3 +30,5 @@ vector<string> JoinSlice(string a, vector<string> slice) {
         result.push_back(slice[i]);
     return result;
 }
+
+#endif // JOIN_SLICE_CPP

--- a/casbin/util/remove_comments.cpp
+++ b/casbin/util/remove_comments.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef REMOVE_COMMENTS_CPP
+#define REMOVE_COMMENTS_CPP
+
 
 #include "./util.h"
 
@@ -30,3 +32,5 @@ string RemoveComments(string s) {
     string fin_str = s.substr(0, pos);
     return Trim(fin_str);
 }
+
+#endif // REMOVE_COMMENTS_CPP

--- a/casbin/util/set_subtract.cpp
+++ b/casbin/util/set_subtract.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef SET_SUBSTRACT_CPP
+#define SET_SUBSTRACT_CPP
+
 
 #include <unordered_map>
 
@@ -37,3 +39,5 @@ vector<string> SetSubtract(vector<string> a, vector<string> b) {
             diff.push_back(a[i]);
     return diff;
 }
+
+#endif // SET_SUBSTRACT_CPP

--- a/casbin/util/split.cpp
+++ b/casbin/util/split.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef SPLIT_CPP
+#define SPLIT_CPP
+
 
 #include <string.h>
 
@@ -44,3 +46,5 @@ vector<string> Split(string str, string del, int limit){
 
     return tokens;
 }
+
+#endif // SPLIT_CPP

--- a/casbin/util/trim.cpp
+++ b/casbin/util/trim.cpp
@@ -14,9 +14,11 @@
 * limitations under the License.
 */
 
-#pragma once
-
 #include "pch.h"
+
+#ifndef TRIM_CPP
+#define TRIM_CPP
+
 
 #include "./util.h"
 
@@ -35,3 +37,5 @@ string& RTrim(string& str, const string& chars) {
 string Trim(string& str, const string& chars) {
     return LTrim(RTrim(str, chars), chars);
 }
+
+#endif // TRIM_CPP

--- a/test/test_built_in_functions.cpp
+++ b/test/test_built_in_functions.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef TEST_BUILT_IN_FUNCTIONS_CPP
+#define TEST_BUILT_IN_FUNCTIONS_CPP
+
 
 #include <util.h>
 
@@ -159,3 +161,5 @@ namespace test_built_in_functions
             }
     };
 }
+
+#endif // TEST_BUILT_IN_FUNCTIONS_CPP

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef TEST_CONFIG_CPP
+#define TEST_CONFIG_CPP
+
 
 #include <config.h>
 #include <util.h>
@@ -60,3 +62,5 @@ namespace test_config
             }
     };
 }
+
+#endif // TEST_CONFIG_CPP

--- a/test/test_enforcer.cpp
+++ b/test/test_enforcer.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef TEST_ENFORCER_CPP
+#define TEST_ENFORCER_CPP
+
 
 #include <enforcer.h>
 #include <persist.h>
@@ -109,3 +111,5 @@ namespace test_enforcer
         }
     };
 }
+
+#endif // TEST_ENFORCER_CPP

--- a/test/test_enforcer_cached.cpp
+++ b/test/test_enforcer_cached.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef TEST_ENFORCER_CACHED_CPP
+#define TEST_ENFORCER_CACHED_CPP
+
 
 #include <enforcer_cached.h>
 
@@ -46,3 +48,5 @@ namespace test_enforcer_cached
 
     };
 }
+
+#endif // TEST_ENFORCER_CACHED_CPP

--- a/test/test_management_api.cpp
+++ b/test/test_management_api.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef TEST_MANAGEMENT_API_CPP
+#define TEST_MANAGEMENT_API_CPP
+
 
 #include <enforcer.h>
 #include <persist.h>
@@ -249,3 +251,5 @@ namespace test_management_api
             }
     };
 }
+
+#endif // TEST_MANAGEMENT_API_CPP

--- a/test/test_model.cpp
+++ b/test/test_model.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef TEST_MODEL_CPP
+#define TEST_MODEL_CPP
+
 
 #include <fstream>
 
@@ -94,3 +96,5 @@ namespace test_model
             }
     };
 }
+
+#endif // TEST_MODEL_CPP

--- a/test/test_model_enforcer.cpp
+++ b/test/test_model_enforcer.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef TEST_MODEL_ENFORCER_CPP
+#define TEST_MODEL_ENFORCER_CPP
+
 
 #include <enforcer.h>
 #include <persist.h>
@@ -789,3 +791,5 @@ namespace test_model_enforcer
             */
     };
 }
+
+#endif // TEST_MODEL_ENFORCER_CPP

--- a/test/test_rbac_api.cpp
+++ b/test/test_rbac_api.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef TEST_RBAC_API_CPP
+#define TEST_RBAC_API_CPP
+
 
 #include <enforcer.h>
 #include <rbac.h>
@@ -225,3 +227,5 @@ namespace test_rbac_api
             }
     };
 }
+
+#endif // TEST_RBAC_API_CPP

--- a/test/test_rbac_api_with_domains.cpp
+++ b/test/test_rbac_api_with_domains.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef TEST_RBAC_API_WITH_DOMAINS_CPP
+#define TEST_RBAC_API_WITH_DOMAINS_CPP
+
 
 #include <enforcer.h>
 #include <exception.h>
@@ -183,3 +185,5 @@ namespace test_rbac_api_with_domains
             }
     };
 }
+
+#endif // TEST_RBAC_API_WITH_DOMAINS_CPP

--- a/test/test_role_manager.cpp
+++ b/test/test_role_manager.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef TEST_ROLE_MANAGER_CPP
+#define TEST_ROLE_MANAGER_CPP
+
 
 #include <rbac.h>
 
@@ -182,3 +184,5 @@ namespace test_role_manager
             }
     };
 }
+
+#endif // TEST_ROLE_MANAGER_CPP

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -1,6 +1,8 @@
-#pragma once
-
 #include "pch.h"
+
+#ifndef TEST_UTIL_CPP
+#define TEST_UTIL_CPP
+
 
 #include <util.h>
 
@@ -59,3 +61,5 @@ namespace test_util
             }
     };
 }
+
+#endif // TEST_UTIL_CPP


### PR DESCRIPTION
Signed-off-by: Yash Pandey (YP) <yash.btech.cs19@iiitranchi.ac.in>

This PR fixes #80 

**Description**
Although `#pragma once` is less prone to errors and is supported by a wide range of compliers, they produce some warnings when compiling with Clang or GCC on MacOS and Linux. I carefully replaced `#pragma once` and implemented include guards in each cpp file. Here is a glimpse of what it looks like for a file, say `foo.cpp`: 

```
// Prelude/License

#include "pch.h"
 
#ifndef FOO_CPP
#define FOO_CPP

// The contents of the file

#endif // FOO_CPP
```

**Note on compilation**

There were no warnings generated on build for all configurations after implementing this.

**Tested on**

OS: Darwin arm64 20.3.0
Compiler: Clang 12.0.0
Effective build time: ~12 seconds