### PR TITLE
feat: Completion of Enforcer API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ if(NOT DEFINED CMAKE_OBJECT_PATH_MAX)
     set(CMAKE_OBJECT_PATH_MAX 300)
 endif()
 
-set(CMAKE_CXX_STANDARD 11)
+# Setting to C++ standard to C++17
+set(CMAKE_CXX_STANDARD 17)
 
 add_subdirectory(casbin)

--- a/casbin/CMakeLists.txt
+++ b/casbin/CMakeLists.txt
@@ -3,3 +3,6 @@ set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 FILE(GLOB_RECURSE SC_FILES "*.cpp" "*.h")
 
 add_library(casbin ${SC_FILES})
+
+set_target_properties(casbin PROPERTIES PREFIX "")
+set_target_properties(casbin PROPERTIES SUFFIX ".o")

--- a/casbin/casbin.vcxproj
+++ b/casbin/casbin.vcxproj
@@ -181,6 +181,7 @@
     <ClCompile Include="ip_parser\parser\parseIPv6.cpp" />
     <ClCompile Include="ip_parser\parser\Print.cpp" />
     <ClCompile Include="ip_parser\parser\xtoi.cpp" />
+    <ClCompile Include="logger.cpp" />
     <ClCompile Include="management_api.cpp" />
     <ClCompile Include="model\assertion.cpp" />
     <ClCompile Include="model\function.cpp" />
@@ -263,6 +264,9 @@
     <ClInclude Include="ip_parser\parser\pch.h" />
     <ClInclude Include="ip_parser\parser\Print.h" />
     <ClInclude Include="ip_parser\parser\xtoi.h" />
+    <ClInclude Include="log\default_logger.h" />
+    <ClInclude Include="log\Logger.h" />
+    <ClInclude Include="log\log_util.h" />
     <ClInclude Include="model.h" />
     <ClInclude Include="model\assertion.h" />
     <ClInclude Include="model\function.h" />

--- a/casbin/casbin.vcxproj.filters
+++ b/casbin/casbin.vcxproj.filters
@@ -261,6 +261,9 @@
     <ClCompile Include="enforcer_synced.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="logger.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="config\config_interface.h">
@@ -480,6 +483,15 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="util\ticker.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="log\default_logger.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="log\log_util.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="log\Logger.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/casbin/enforcer_interface.h
+++ b/casbin/enforcer_interface.h
@@ -57,9 +57,11 @@ class IEnforcer {
         virtual void EnableAutoSave(bool auto_save) = 0;
         virtual void EnableAutoBuildRoleLinks(bool auto_build_role_links) = 0;
         virtual void BuildRoleLinks() = 0;
-        virtual bool enforce(const std::string&matcher, Scope scope) = 0;
+        virtual bool m_enforce(const std::string& matcher, Scope scope) = 0;
         virtual bool Enforce(Scope scope) = 0;
-        virtual bool EnforceWithMatcher(const std::string&matcher, Scope scope) = 0;
+        virtual bool EnforceWithMatcher(const std::string& matcher, Scope scope) = 0;
+        virtual std::vector<bool> BatchEnforce(const std::vector<std::vector<std::string>>& requests) = 0;
+        virtual std::vector<bool> BatchEnforceWithMatcher(const std::string& matcher, const std::vector<std::vector<std::string>>& requests) = 0;
 
         /* RBAC API */
         virtual std::vector<std::string> GetRolesForUser(const std::string& name, const std::vector<std::string>& domain = {}) = 0;
@@ -123,6 +125,12 @@ class IEnforcer {
         virtual bool RemoveNamedGroupingPolicies(const std::string& p_type, const std::vector<std::vector<std::string>>& rules) = 0;
         virtual bool RemoveFilteredNamedGroupingPolicy(const std::string& p_type, int field_index, const std::vector<std::string>& field_values) = 0;
         virtual void AddFunction(const std::string& name, Function function, Index nargs) = 0;
+        virtual bool UpdateGroupingPolicy(const std::vector<std::string>& oldRule, const std::vector<std::string>& newRule) = 0;
+        virtual bool UpdateNamedGroupingPolicy(const std::string& ptype, const std::vector<std::string>& oldRule, const std::vector<std::string>& newRule) = 0;
+        virtual bool UpdatePolicy(const std::vector<std::string>& oldPolicy, const std::vector<std::string>& newPolicy) = 0;
+        virtual bool UpdateNamedPolicy(const std::string& ptype, const std::vector<std::string>& p1, const std::vector<std::string>& p2) = 0;
+        virtual bool UpdatePolicies(const std::vector<std::vector<std::string>>& oldPolices, const std::vector<std::vector<std::string>>& newPolicies) = 0;
+        virtual bool UpdateNamedPolicies(const std::string& ptype, const std::vector<std::vector<std::string>>& p1, const std::vector<std::vector<std::string>>& p2) = 0;
 
         /* Internal API member functions */
         virtual bool addPolicy(const std::string& sec, const std::string& p_type, const std::vector<std::string>& rule) = 0;
@@ -130,6 +138,8 @@ class IEnforcer {
         virtual bool removePolicy(const std::string& sec , const std::string& p_type , const std::vector<std::string>& rule) = 0;
         virtual bool removePolicies(const std::string& sec, const std::string& p_type, const std::vector<std::vector<std::string>>& rules) = 0;
         virtual bool removeFilteredPolicy(const std::string& sec , const std::string& p_type , int field_index , const std::vector<std::string>& field_values) = 0;
+        virtual bool updatePolicy(const std::string& sec, const std::string& p_type, const std::vector<std::string>& oldRule, const std::vector<std::string>& newRule) = 0;
+        virtual bool updatePolicies(const std::string& sec, const std::string& p_type, const std::vector<std::vector<std::string>>& p1, const std::vector<std::vector<std::string>>& p2) = 0;
 
         /* RBAC API with domains.*/
         virtual std::vector<std::string> GetUsersForRoleInDomain(const std::string& name, const std::string& domain) = 0;

--- a/casbin/enforcer_synced.cpp
+++ b/casbin/enforcer_synced.cpp
@@ -201,17 +201,17 @@ bool SyncedEnforcer ::Enforce(const std::unordered_map<std::string, std::string>
     return Enforcer::Enforce(params);
 }
 
-// // BatchEnforce enforce in batches
-// std::vector<bool> SyncedEnforcer ::BatchEnforce(const std::vector<std::vector<std::string>>& requests) {
-//   std::lock_guard<std::mutex> lock(policyMutex);
-//   return Enforcer::BatchEnforce(requests);
-// }
+// BatchEnforce enforce in batches
+std::vector<bool> SyncedEnforcer ::BatchEnforce(const std::vector<std::vector<std::string>>& requests) {
+  std::lock_guard<std::mutex> lock(policyMutex);
+  return Enforcer::BatchEnforce(requests);
+}
 
-// // BatchEnforceWithMatcher enforce with matcher in batches
-// std::vector<bool> SyncedEnforcer ::BatchEnforceWithMatcher(const std::string& matcher, const std::vector<std::vector<std::string>>& requests) {
-//   std::lock_guard<std::mutex> lock(policyMutex);
-//   return Enforcer::BatchEnforce(matcher, requests);
-// }
+// BatchEnforceWithMatcher enforce with matcher in batches
+std::vector<bool> SyncedEnforcer ::BatchEnforceWithMatcher(const std::string& matcher, const std::vector<std::vector<std::string>>& requests) {
+  std::lock_guard<std::mutex> lock(policyMutex);
+  return Enforcer::BatchEnforceWithMatcher(matcher, requests);
+}
 
 // GetAllSubjects gets the list of subjects that show up in the current policy.
 std::vector<std::string> SyncedEnforcer ::GetAllSubjects() {
@@ -348,26 +348,26 @@ bool SyncedEnforcer ::RemovePolicy(const std::vector<std::string>& params) {
 }
 
 // UpdatePolicy updates an authorization rule from the current policy.
-// bool SyncedEnforcer ::UpdatePolicy(const std::vector<std::string>& oldPolicy, const std::vector<std::string>& newPolicy) {
-//   std::lock_guard<std::mutex> lock(policyMutex);
-//   return Enforcer::UpdatePolicy(oldPolicy, newPolicy);
-// }
+bool SyncedEnforcer ::UpdatePolicy(const std::vector<std::string>& oldPolicy, const std::vector<std::string>& newPolicy) {
+  std::lock_guard<std::mutex> lock(policyMutex);
+  return Enforcer::UpdatePolicy(oldPolicy, newPolicy);
+}
 
-// bool SyncedEnforcer ::UpdateNamedPolicy(const std::string& ptype, const std::vector<std::string>& p1, const std::vector<std::string>& p2) {
-//   std::lock_guard<std::mutex> lock(policyMutex);
-//   return Enforcer::UpdateNamedPolicy(ptype, p1, p2);
-// }
+bool SyncedEnforcer ::UpdateNamedPolicy(const std::string& ptype, const std::vector<std::string>& p1, const std::vector<std::string>& p2) {
+  std::lock_guard<std::mutex> lock(policyMutex);
+  return Enforcer::UpdateNamedPolicy(ptype, p1, p2);
+}
 
-// // UpdatePolicies updates authorization rules from the current policies.
-// bool SyncedEnforcer ::UpdatePolicies(const std::vector<std::vector<std::string>>& oldPolices, const std::vector<std::vector<std::string>>& newPolicies) {
-//   std::lock_guard<std::mutex> lock(policyMutex);
-//   return Enforcer::UpdatePolicies(oldPolices, newPolicies);
-// }
+// UpdatePolicies updates authorization rules from the current policies.
+bool SyncedEnforcer ::UpdatePolicies(const std::vector<std::vector<std::string>>& oldPolices, const std::vector<std::vector<std::string>>& newPolicies) {
+  std::lock_guard<std::mutex> lock(policyMutex);
+  return Enforcer::UpdatePolicies(oldPolices, newPolicies);
+}
 
-// bool SyncedEnforcer ::UpdateNamedPolicies(const std::string& ptype, const std::vector<std::vector<std::string>>& p1, const std::vector<std::vector<std::string>>& p2) {
-//   std::lock_guard<std::mutex> lock(policyMutex);
-//   return Enforcer::UpdateNamedPolicies(ptype, p1, p2);
-// }
+bool SyncedEnforcer ::UpdateNamedPolicies(const std::string& ptype, const std::vector<std::vector<std::string>>& p1, const std::vector<std::vector<std::string>>& p2) {
+  std::lock_guard<std::mutex> lock(policyMutex);
+  return Enforcer::UpdateNamedPolicies(ptype, p1, p2);
+}
 
 // RemovePolicies removes authorization rules from the current policy.
 bool SyncedEnforcer ::RemovePolicies(const std::vector<std::vector<std::string>>& rules) {
@@ -473,15 +473,15 @@ bool SyncedEnforcer ::RemoveNamedGroupingPolicies(const std::string& ptype, cons
     return Enforcer::RemoveNamedGroupingPolicies(ptype, rules);
 }
 
-// bool SyncedEnforcer ::UpdateGroupingPolicy(const std::vector<std::string>& oldRule, const std::vector<std::string>& newRule) {
-//   std::lock_guard<std::mutex> lock(policyMutex);
-//   return Enforcer::UpdateGroupingPolicy(oldRule, newRule);
-// }
+bool SyncedEnforcer ::UpdateGroupingPolicy(const std::vector<std::string>& oldRule, const std::vector<std::string>& newRule) {
+  std::lock_guard<std::mutex> lock(policyMutex);
+  return Enforcer::UpdateGroupingPolicy(oldRule, newRule);
+}
 
-// bool SyncedEnforcer ::UpdateNamedGroupingPolicy(const std::string& ptype, const std::vector<std::string>& oldRule, const std::vector<std::string>& newRule) {
-//   std::lock_guard<std::mutex> lock(policyMutex);
-//   return Enforcer::UpdateNamedGroupingPolicy(ptype, oldRule, newRule);
-// }
+bool SyncedEnforcer ::UpdateNamedGroupingPolicy(const std::string& ptype, const std::vector<std::string>& oldRule, const std::vector<std::string>& newRule) {
+  std::lock_guard<std::mutex> lock(policyMutex);
+  return Enforcer::UpdateNamedGroupingPolicy(ptype, oldRule, newRule);
+}
 
 // RemoveFilteredNamedGroupingPolicy removes a role inheritance rule from the current named policy, field filters can be specified.
 bool SyncedEnforcer ::RemoveFilteredNamedGroupingPolicy(const std::string& ptype, int fieldIndex, const std::vector<std::string>& fieldValues) {

--- a/casbin/internal_api.cpp
+++ b/casbin/internal_api.cpp
@@ -30,7 +30,7 @@ namespace casbin {
 
 // addPolicy adds a rule to the current policy.
 bool Enforcer :: addPolicy(const std::string& sec, const std::string& p_type, const std::vector<std::string>& rule) {
-    bool rule_added = this->model->AddPolicy(sec, p_type, rule);
+    bool rule_added = m_model->AddPolicy(sec, p_type, rule);
     if(!rule_added)
         return rule_added;
 
@@ -39,20 +39,20 @@ bool Enforcer :: addPolicy(const std::string& sec, const std::string& p_type, co
         this->BuildIncrementalRoleLinks(policy_add, p_type, rules);
     }
 
-    if (this->adapter && this->auto_save) {
+    if (m_adapter && m_auto_save) {
         try {
-            this->adapter->AddPolicy(sec, p_type, rule);
+            m_adapter->AddPolicy(sec, p_type, rule);
         }
         catch(UnsupportedOperationException e) {
         }
     }
 
-    if (this->watcher && this->auto_notify_watcher) {
-        if (IsInstanceOf<WatcherEx>(this->watcher.get())) {
-            std::dynamic_pointer_cast<WatcherEx>(this->watcher)->UpdateForAddPolicy(rule);
+    if (m_watcher && m_auto_notify_watcher) {
+        if (IsInstanceOf<WatcherEx>(m_watcher.get())) {
+            std::dynamic_pointer_cast<WatcherEx>(m_watcher)->UpdateForAddPolicy(rule);
         }
         else
-            this->watcher->Update();
+            m_watcher->Update();
     }
 
     return rule_added;
@@ -60,7 +60,7 @@ bool Enforcer :: addPolicy(const std::string& sec, const std::string& p_type, co
 
 // addPolicies adds rules to the current policy.
 bool Enforcer :: addPolicies(const std::string& sec, const std::string& p_type, const std::vector<std::vector<std::string>>& rules) {
-    bool rules_added = this->model->AddPolicies(sec, p_type, rules);
+    bool rules_added = m_model->AddPolicies(sec, p_type, rules);
     if (!rules_added)
         return rules_added;
 
@@ -68,23 +68,23 @@ bool Enforcer :: addPolicies(const std::string& sec, const std::string& p_type, 
         this->BuildIncrementalRoleLinks(policy_add, p_type, rules);
 
 
-    if (this->adapter && this->auto_save) {
+    if (m_adapter && m_auto_save) {
         try {
-            std::dynamic_pointer_cast<BatchAdapter>(this->adapter)->AddPolicies(sec, p_type, rules);
+            std::dynamic_pointer_cast<BatchAdapter>(m_adapter)->AddPolicies(sec, p_type, rules);
         }
         catch(UnsupportedOperationException e) {
         }
     }
 
-    if (this->watcher && this->auto_notify_watcher)
-        this->watcher->Update();
+    if (m_watcher && m_auto_notify_watcher)
+        m_watcher->Update();
 
     return rules_added;
 }
 
 // removePolicy removes a rule from the current policy.
 bool Enforcer :: removePolicy(const std::string& sec, const std::string& p_type, const std::vector<std::string>& rule) {
-    bool rule_removed = this->model->RemovePolicy(sec, p_type, rule);
+    bool rule_removed = m_model->RemovePolicy(sec, p_type, rule);
     if(!rule_removed)
         return rule_removed;
 
@@ -93,20 +93,20 @@ bool Enforcer :: removePolicy(const std::string& sec, const std::string& p_type,
         this->BuildIncrementalRoleLinks(policy_add, p_type, rules);
     }
     
-    if (this->adapter && this->auto_save) {
+    if (m_adapter && m_auto_save) {
         try {
-            this->adapter->RemovePolicy(sec, p_type, rule);
+            m_adapter->RemovePolicy(sec, p_type, rule);
         }
         catch (UnsupportedOperationException e) {
         }
     }
 
-    if(this->watcher && this->auto_notify_watcher){
-        if (IsInstanceOf<WatcherEx>(this->watcher.get())) {
-            std::dynamic_pointer_cast<WatcherEx>(watcher)->UpdateForRemovePolicy(rule);
+    if(m_watcher && m_auto_notify_watcher){
+        if (IsInstanceOf<WatcherEx>(m_watcher.get())) {
+            std::dynamic_pointer_cast<WatcherEx>(m_watcher)->UpdateForRemovePolicy(rule);
         }
         else
-            this->watcher->Update();
+            m_watcher->Update();
     }
 
     return rule_removed;
@@ -114,30 +114,30 @@ bool Enforcer :: removePolicy(const std::string& sec, const std::string& p_type,
 
 // removePolicies removes rules from the current policy.
 bool Enforcer :: removePolicies(const std::string& sec, const std::string& p_type, const std::vector<std::vector<std::string>>& rules) {
-    bool rules_removed = this->model->AddPolicies(sec, p_type, rules);
+    bool rules_removed = m_model->AddPolicies(sec, p_type, rules);
     if (!rules_removed)
         return rules_removed;
 
     if (sec == "g")
         this->BuildIncrementalRoleLinks(policy_add, p_type, rules);
 
-    if (this->adapter && this->auto_save) {
+    if (m_adapter && m_auto_save) {
         try{
-            std::dynamic_pointer_cast<BatchAdapter>(this->adapter)->RemovePolicies(sec, p_type, rules);
+            std::dynamic_pointer_cast<BatchAdapter>(m_adapter)->RemovePolicies(sec, p_type, rules);
         }
         catch(UnsupportedOperationException e){
         }
     }
 
-    if (this->watcher && this->auto_notify_watcher)
-        this->watcher->Update();
+    if (m_watcher && m_auto_notify_watcher)
+        m_watcher->Update();
 
     return rules_removed;
 }
 
 // removeFilteredPolicy removes rules based on field filters from the current policy.
 bool Enforcer :: removeFilteredPolicy(const std::string& sec, const std::string& p_type, int field_index, const std::vector<std::string>& field_values){
-    std::pair<int, std::vector<std::vector<std::string>>> p = this->model->RemoveFilteredPolicy(sec, p_type, field_index, field_values);
+    std::pair<int, std::vector<std::vector<std::string>>> p = m_model->RemoveFilteredPolicy(sec, p_type, field_index, field_values);
     bool rule_removed = p.first;
     std::vector<std::vector<std::string>> effects = p.second;
 
@@ -147,23 +147,31 @@ bool Enforcer :: removeFilteredPolicy(const std::string& sec, const std::string&
     if (sec == "g")
         this->BuildIncrementalRoleLinks(policy_remove, p_type, effects);
 
-    if (this->adapter && this->auto_save) {
+    if (m_adapter && m_auto_save) {
         try {
-            this->adapter->RemoveFilteredPolicy(sec, p_type, field_index, field_values); \
+            m_adapter->RemoveFilteredPolicy(sec, p_type, field_index, field_values); \
         }
         catch (UnsupportedOperationException e) {
         }
     }
 
-    if (this->watcher && this->auto_notify_watcher) {
-        if (IsInstanceOf<WatcherEx>(this->watcher.get())) {
-            std::dynamic_pointer_cast<WatcherEx>(this->watcher)->UpdateForRemoveFilteredPolicy(field_index, field_values);
+    if (m_watcher && m_auto_notify_watcher) {
+        if (IsInstanceOf<WatcherEx>(m_watcher.get())) {
+            std::dynamic_pointer_cast<WatcherEx>(m_watcher)->UpdateForRemoveFilteredPolicy(field_index, field_values);
         }
         else
-            this->watcher->Update();
+            m_watcher->Update();
     }
 
     return rule_removed;
+}
+
+bool Enforcer :: updatePolicy(const std::string& sec, const std::string& p_type, const std::vector<std::string>& oldRule, const std::vector<std::string>& newRule) {
+    return true;
+}
+
+bool Enforcer :: updatePolicies(const std::string& sec, const std::string& p_type, const std::vector<std::vector<std::string>>& p1, const std::vector<std::vector<std::string>>& p2) {
+    return true;
 }
 
 } // namespace casbin

--- a/casbin/log/Logger.h
+++ b/casbin/log/Logger.h
@@ -7,27 +7,23 @@ namespace casbin {
 
 class Logger{
     protected:
-        bool enable;
+        bool m_enable;
 
     public:
     
         //EnableLog controls whether print the message.
-        virtual void EnableLog(bool enable);
+        virtual void EnableLog(bool enable) = 0;
 
         //IsEnabled returns if logger is enabled.
-        virtual bool IsEnabled();
+        virtual bool IsEnabled() = 0;
 
         //Print formats using the default formats for its operands and logs the message.
-        template <typename... Object>
-        void Print(Object... objects){
-            return;
-        }
+        template <typename T, typename... Object>
+        void Print(T arg, Object... objects);
 
         //Printf formats according to a format specifier and logs the message.
         template <typename... Object>
-        void Printf(std::string, Object... objects){
-            return;
-        }
+        void Printf(std::string, Object... objects);
 };
 
 } // namespace casbin

--- a/casbin/log/default_logger.h
+++ b/casbin/log/default_logger.h
@@ -1,32 +1,31 @@
 #ifndef CASBIN_CPP_LOG_DEFAULT_LOGGER
 #define CASBIN_CPP_LOG_DEFAULT_LOGGER
 
-#include "Logger.h"
-#include "Log.h"
+#include "./Logger.h"
 
 namespace casbin {
 
-class DefaultLogger : public Logger{
+class DefaultLogger : public Logger {
     public:
 
         void EnableLog(bool enable) {
-            this->enable = enable;
+            m_enable = enable;
         }
 
         bool IsEnabled() {
-            return this->enable;
+            return m_enable;
         }
 
         template <typename... Object>
         void Print(Object... objects){
-            if (this->enable){
+            if (m_enable){
                 Print(objects...);
             }
         }
 
         template <typename... Object>
         void Print(std::string format, Object... objects){
-            if (this->enable){
+            if (m_enable){
                 Printf(format, objects...);
             }
         }

--- a/casbin/log/log_util.h
+++ b/casbin/log/log_util.h
@@ -1,36 +1,36 @@
 #ifndef CASBIN_CPP_LOG_LOG_UTIL
 #define CASBIN_CPP_LOG_LOG_UTIL
 
-#include "DefaultLogger.h"
+#include "./default_logger.h"
 
 namespace casbin {
 
 
-class LogUtil{
+class LogUtil {
 	private:
-		static Logger logger;
+    static DefaultLogger s_logger;
 	public:
 
 		// SetLogger sets the current logger.
-		static void SetLogger(Logger l){
-			logger = l;
+		static void SetLogger(const DefaultLogger& l){
+			s_logger = l;
 		}
 
 		// GetLogger returns the current logger.
-		static Logger GetLogger() {
-			return logger;
+        static DefaultLogger GetLogger() {
+			return s_logger;
 		}
 
 		// LogPrint prints the log.
 		template <typename... Object>
 		static void LogPrint(Object... objects) {
-			logger.Print(objects...);
+			s_logger.Print(objects...);
 		}
 
 		// LogPrintf prints the log with the format.
 		template <typename... Object>
 		static void LogPrintf(std::string format, Object... objects) {
-			logger.Printf(format, objects...);
+			s_logger.Printf(format, objects...);
 		}
 };
 

--- a/casbin/logger.cpp
+++ b/casbin/logger.cpp
@@ -1,0 +1,28 @@
+#include "pch.h"
+
+#ifndef LOGGER_CPP
+#define LOGGER_CPP
+
+#include <iostream>
+#include "log/Logger.h"
+#include "log/log_util.h"
+
+namespace casbin {
+
+//Print formats using the default formats for its operands and logs the message.
+template <typename T, typename... Object>
+void Logger::Print(T arg, Object... objects) {
+    return;
+}
+
+//Printf formats according to a format specifier and logs the message.
+template <typename... Object>
+void Logger::Printf(std::string format, Object... objects) {
+    Print(objects...);
+}
+
+DefaultLogger LogUtil::s_logger;
+
+}
+
+#endif // LOGGER_CPP

--- a/casbin/management_api.cpp
+++ b/casbin/management_api.cpp
@@ -26,42 +26,42 @@ namespace casbin {
 
 // GetAllSubjects gets the list of subjects that show up in the current policy.
 std::vector<std::string> Enforcer :: GetAllSubjects() {
-    return this->model->GetValuesForFieldInPolicyAllTypes("p", 0);
+    return m_model->GetValuesForFieldInPolicyAllTypes("p", 0);
 }
 
 // GetAllNamedSubjects gets the list of subjects that show up in the current named policy.
 std::vector<std::string> Enforcer :: GetAllNamedSubjects(const std::string& p_type) {
-    return this->model->GetValuesForFieldInPolicy("p", p_type, 0);
+    return m_model->GetValuesForFieldInPolicy("p", p_type, 0);
 }
 
 // GetAllObjects gets the list of objects that show up in the current policy.
 std::vector<std::string> Enforcer :: GetAllObjects() {
-    return this->model->GetValuesForFieldInPolicyAllTypes("p", 1);
+    return m_model->GetValuesForFieldInPolicyAllTypes("p", 1);
 }
 
 // GetAllNamedObjects gets the list of objects that show up in the current named policy.
 std::vector<std::string> Enforcer :: GetAllNamedObjects(const std::string& p_type) {
-    return this->model->GetValuesForFieldInPolicy("p", p_type, 1);
+    return m_model->GetValuesForFieldInPolicy("p", p_type, 1);
 }
 
 // GetAllActions gets the list of actions that show up in the current policy.
 std::vector<std::string> Enforcer :: GetAllActions() {
-    return this->model->GetValuesForFieldInPolicyAllTypes("p", 2);
+    return m_model->GetValuesForFieldInPolicyAllTypes("p", 2);
 }
 
 // GetAllNamedActions gets the list of actions that show up in the current named policy.
 std::vector<std::string> Enforcer :: GetAllNamedActions(const std::string& p_type) {
-    return this->model->GetValuesForFieldInPolicy("p", p_type, 2);
+    return m_model->GetValuesForFieldInPolicy("p", p_type, 2);
 }
 
 // GetAllRoles gets the list of roles that show up in the current policy.
 std::vector<std::string> Enforcer :: GetAllRoles() {
-    return this->model->GetValuesForFieldInPolicyAllTypes("g", 1);
+    return m_model->GetValuesForFieldInPolicyAllTypes("g", 1);
 }
 
 // GetAllNamedRoles gets the list of roles that show up in the current named policy.
 std::vector<std::string> Enforcer :: GetAllNamedRoles(const std::string& p_type) {
-    return this->model->GetValuesForFieldInPolicy("g", p_type, 1);
+    return m_model->GetValuesForFieldInPolicy("g", p_type, 1);
 }
 
 // GetPolicy gets all the authorization rules in the policy.
@@ -76,12 +76,12 @@ std::vector<std::vector<std::string>> Enforcer :: GetFilteredPolicy(int field_in
 
 // GetNamedPolicy gets all the authorization rules in the named policy.
 std::vector<std::vector<std::string>> Enforcer :: GetNamedPolicy(const std::string& p_type) {
-    return this->model->GetPolicy("p", p_type);
+    return m_model->GetPolicy("p", p_type);
 }
 
 // GetFilteredNamedPolicy gets all the authorization rules in the named policy, field filters can be specified.
 std::vector<std::vector<std::string>> Enforcer :: GetFilteredNamedPolicy(const std::string& p_type, int field_index, const std::vector<std::string>& field_values) {
-    return this->model->GetFilteredPolicy("p", p_type, field_index, field_values);
+    return m_model->GetFilteredPolicy("p", p_type, field_index, field_values);
 }
 
 // GetGroupingPolicy gets all the role inheritance rules in the policy.
@@ -96,12 +96,12 @@ std::vector<std::vector<std::string>> Enforcer :: GetFilteredGroupingPolicy(int 
 
 // GetNamedGroupingPolicy gets all the role inheritance rules in the policy.
 std::vector<std::vector<std::string>> Enforcer :: GetNamedGroupingPolicy(const std::string& p_type) {
-    return this->model->GetPolicy("g", p_type);
+    return m_model->GetPolicy("g", p_type);
 }
 
 // GetFilteredNamedGroupingPolicy gets all the role inheritance rules in the policy, field filters can be specified.
 std::vector<std::vector<std::string>> Enforcer :: GetFilteredNamedGroupingPolicy(const std::string& p_type, int field_index, const std::vector<std::string>& field_values) {
-    return this->model->GetFilteredPolicy("g", p_type, field_index, field_values);
+    return m_model->GetFilteredPolicy("g", p_type, field_index, field_values);
 }
 
 // HasPolicy determines whether an authorization rule exists.
@@ -113,13 +113,13 @@ bool Enforcer :: HasPolicy(const std::vector<std::string>& params) {
 bool Enforcer :: HasNamedPolicy(const std::string& p_type, const std::vector<std::string>& params) {
     if (params.size() == 1) {
         std::vector<std::string> str_slice{params[0]};
-        return this->model->HasPolicy("p", p_type, str_slice);
+        return m_model->HasPolicy("p", p_type, str_slice);
     }
 
     std::vector<std::string> policy;
     for (int i = 0 ; i < params.size() ; i++)
         policy.push_back(params[i]);
-    return this->model->HasPolicy("p", p_type, policy);
+    return m_model->HasPolicy("p", p_type, policy);
 }
 
 // AddPolicy adds an authorization rule to the current policy.
@@ -205,13 +205,13 @@ bool Enforcer :: HasGroupingPolicy(const std::vector<std::string>& params) {
 bool Enforcer :: HasNamedGroupingPolicy(const std::string& p_type, const std::vector<std::string>& params) {
     if (params.size() == 1) {
         std::vector<std::string> str_slice{params[0]};
-        return this->model->HasPolicy("g", p_type, str_slice);
+        return m_model->HasPolicy("g", p_type, str_slice);
     }
 
     std::vector<std::string> policy;
     for (int i = 0 ; i < params.size() ; i++)
         policy.push_back(params[i]);
-    return this->model->HasPolicy("g", p_type, policy);
+    return m_model->HasPolicy("g", p_type, policy);
 }
 
 // AddGroupingPolicy adds a role inheritance rule to the current policy.
@@ -244,7 +244,7 @@ bool Enforcer :: AddNamedGroupingPolicy(const std::string& p_type, const std::ve
         rule_added = this->addPolicy("g", p_type, policy);
     }
 
-    if(this->auto_build_role_links)
+    if(m_auto_build_role_links)
         this->BuildRoleLinks();
 
     return rule_added;
@@ -286,7 +286,7 @@ bool Enforcer :: RemoveNamedGroupingPolicy(const std::string& p_type, const std:
         rule_removed = this->removePolicy("g", p_type, policy);
     }
 
-    if(this->auto_build_role_links)
+    if(m_auto_build_role_links)
         this->BuildRoleLinks();
 
     return rule_removed;
@@ -301,7 +301,7 @@ bool Enforcer :: RemoveNamedGroupingPolicies(const std::string& p_type,  const s
 bool Enforcer :: RemoveFilteredNamedGroupingPolicy(const std::string& p_type, int field_index, const std::vector<std::string>& field_values) {
     bool rule_removed = this->removeFilteredPolicy("g", p_type, field_index, field_values);
 
-    if(this->auto_build_role_links)
+    if(m_auto_build_role_links)
         this->BuildRoleLinks();
 
     return rule_removed;
@@ -309,7 +309,34 @@ bool Enforcer :: RemoveFilteredNamedGroupingPolicy(const std::string& p_type, in
 
 // AddFunction adds a customized function.
 void Enforcer :: AddFunction(const std::string& name, Function function, Index nargs) {
-    user_func_list.push_back(make_tuple(name, function, nargs));
+    m_user_func_list.push_back(make_tuple(name, function, nargs));
+}
+
+
+bool Enforcer :: UpdateGroupingPolicy(const std::vector<std::string>& oldRule, const std::vector<std::string>& newRule) {
+    return UpdateNamedGroupingPolicy("g", oldRule, newRule);
+}
+
+bool Enforcer :: UpdateNamedGroupingPolicy(const std::string& p_type, const std::vector<std::string>& oldRule, const std::vector<std::string>& newRule) {
+    return this->updatePolicy("g", p_type, oldRule, newRule);
+}
+
+// UpdatePolicy updates an authorization rule from the current policy.
+bool Enforcer :: UpdatePolicy(const std::vector<std::string>& oldPolicy, const std::vector<std::string>& newPolicy) {
+    return UpdateNamedPolicy("p", oldPolicy, newPolicy);
+}
+
+bool Enforcer :: UpdateNamedPolicy(const std::string& ptype, const std::vector<std::string>& p1, const std::vector<std::string>& p2) {
+    return this->updatePolicy("p", ptype, p1, p2);
+}
+
+// UpdatePolicies updates authorization rules from the current policies.
+bool Enforcer :: UpdatePolicies(const std::vector<std::vector<std::string>>& oldPolices, const std::vector<std::vector<std::string>>& newPolicies) {
+    return UpdateNamedPolicies("p", oldPolices, newPolicies);
+}
+
+bool Enforcer :: UpdateNamedPolicies(const std::string& ptype, const std::vector<std::vector<std::string>>& p1, const std::vector<std::vector<std::string>>& p2) {
+    return this->updatePolicies("p", ptype, p1, p2);
 }
 
 } // namespace casbin

--- a/casbin/rbac_api.cpp
+++ b/casbin/rbac_api.cpp
@@ -28,13 +28,13 @@ namespace casbin {
 
 // GetRolesForUser gets the roles that a user has.
 std::vector<std::string> Enforcer :: GetRolesForUser(const std::string& name, const std::vector<std::string>& domain) {
-    std::vector<std::string> res = this->model->m["g"].assertion_map["g"]->rm->GetRoles(name, domain);
+    std::vector<std::string> res = m_model->m["g"].assertion_map["g"]->rm->GetRoles(name, domain);
     return res;
 }
 
 // GetUsersForRole gets the users that has a role.
 std::vector<std::string> Enforcer :: GetUsersForRole(const std::string& name, const std::vector<std::string>& domain) {
-    std::vector<std::string> res = this->model->m["g"].assertion_map["g"]->rm->GetUsers(name, domain);
+    std::vector<std::string> res = m_model->m["g"].assertion_map["g"]->rm->GetUsers(name, domain);
     return res;
 }
 
@@ -168,7 +168,7 @@ std::vector<std::string> Enforcer :: GetImplicitRolesForUser(const std::string& 
         std::string name = q[0];
         q.erase(q.begin());
 
-        std::vector<std::string> roles = this->rm->GetRoles(name, domain);
+        std::vector<std::string> roles = rm->GetRoles(name, domain);
 
         for (int i = 0 ; i < roles.size() ; i++) {
             if (!(role_set.find(roles[i]) != role_set.end())) {
@@ -227,8 +227,8 @@ std::vector<std::vector<std::string>> Enforcer :: GetImplicitPermissionsForUser(
 // Note: only users will be returned, roles (2nd arg in "g") will be excluded.
 std::vector<std::string> Enforcer :: GetImplicitUsersForPermission(const std::vector<std::string>& permission) {
     std::vector<std::string> p_subjects = this->GetAllSubjects();
-    std::vector<std::string> g_inherit = this->model->GetValuesForFieldInPolicyAllTypes("g", 1);
-    std::vector<std::string> g_subjects = this->model->GetValuesForFieldInPolicyAllTypes("g", 0);
+    std::vector<std::string> g_inherit = m_model->GetValuesForFieldInPolicyAllTypes("g", 1);
+    std::vector<std::string> g_subjects = m_model->GetValuesForFieldInPolicyAllTypes("g", 0);
 
     std::vector<std::string> subjects(p_subjects);
     subjects.insert(subjects.end(), g_subjects.begin(), g_subjects.end());

--- a/casbin/rbac_api_with_domains.cpp
+++ b/casbin/rbac_api_with_domains.cpp
@@ -27,14 +27,14 @@ namespace casbin {
 // GetUsersForRoleInDomain gets the users that has a role inside a domain. Add by Gordon
 std::vector<std::string> Enforcer :: GetUsersForRoleInDomain(const std::string& name, const std::string& domain) {
     std::vector<std::string> domains{domain};
-	std::vector<std::string> res = this->model->m["g"].assertion_map["g"]->rm->GetUsers(name, domains);
+	std::vector<std::string> res = m_model->m["g"].assertion_map["g"]->rm->GetUsers(name, domains);
 	return res;
 }
 
 // GetRolesForUserInDomain gets the roles that a user has inside a domain.
 std::vector<std::string> Enforcer :: GetRolesForUserInDomain(const std::string& name, const std::string& domain) {
     std::vector<std::string> domains{domain};
-	std::vector<std::string> res = this->model->m["g"].assertion_map["g"]->rm->GetRoles(name, domains);
+	std::vector<std::string> res = m_model->m["g"].assertion_map["g"]->rm->GetRoles(name, domains);
 	return res;
 }
 

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ AR := ar
 # Define compiler flags
 OBJ_FLAG := -c
 FILE_FLAG := -o
-STD_FLAG := -std=c++11
+STD_FLAG := -std=c++17
 DIS_WARN := -w
 
 # Define archive flags


### PR DESCRIPTION
Fixes #96 **partially**

Signed-off-by: Yash Pandey (YP) <yash.btech.cs19@iiitranchi.ac.in>

---

**Description**

- This code implements some methods of the enforcer API components from [casbin](https://github.com/casbin/casbin) to be on par with GoLang variant. Some of them includes :

```cpp
// Public API
std::vector<bool> BatchEnforce(const std::vector<std::vector<std::string>>& requests);
std::vector<bool> BatchEnforceWithMatcher(const std::string& matcher, const std::vector<std::vector<std::string>>& requests);

// Management API functions
bool UpdateGroupingPolicy(const std::vector<std::string>& oldRule, const std::vector<std::string>& newRule);
bool UpdateNamedGroupingPolicy(const std::string& ptype, const std::vector<std::string>& oldRule, const std::vector<std::string>& newRule);
bool UpdatePolicy(const std::vector<std::string>& oldPolicy, const std::vector<std::string>& newPolicy);
bool UpdateNamedPolicy(const std::string& ptype, const std::vector<std::string>& p1, const std::vector<std::string>& p2);
bool UpdatePolicies(const std::vector<std::vector<std::string>>& oldPolices, const std::vector<std::vector<std::string>>& newPolicies);
bool UpdateNamedPolicies(const std::string& ptype, const std::vector<std::vector<std::string>>& p1, const std::vector<std::vector<std::string>>& p2);

// RBAC API member functions.
bool updatePolicy(const std::string& sec, const std::string& p_type, const std::vector<std::string>& oldRule, const std::vector<std::string>& newRule);
bool updatePolicies(const std::string& sec, const std::string& p_type, const std::vector<std::vector<std::string>>& p1, const std::vector<std::vector<std::string>>& p2);
```

- It also changes the convention of using `this->privateMember` to access private members of a class to just `m_privateMember`.

- In compliance with const reference for strings and vectors to prevent multiple allocations.



