### PR TITLE
chore: Model Cleanup

### DIFF
--- a/casbin/model/assertion.cpp
+++ b/casbin/model/assertion.cpp
@@ -27,43 +27,40 @@
 
 namespace casbin {
 
-void Assertion :: BuildIncrementalRoleLinks(std::shared_ptr<RoleManager> rm, policy_op op, std::vector<std::vector<std::string>> rules) {
+void Assertion::BuildIncrementalRoleLinks(std::shared_ptr<RoleManager> rm, policy_op op, const std::vector<std::vector<std::string>>& rules) {
     this->rm = rm;
-    int char_count = int(count(this->value.begin(), this->value.end(), '_'));
+    size_t char_count = count(this->value.begin(), this->value.end(), '_');
 
     if (char_count < 2)
         throw IllegalArgumentException("the number of \"_\" in role definition should be at least 2");
 
-    for(int i = 0 ; i < rules.size() ; i++){
-        std::vector<std::string> rule = rules[i];
-
+    for(std::vector<std::string> rule : rules) {
         if (rule.size() < char_count)
             throw IllegalArgumentException("grouping policy elements do not meet role definition");
+
         if (rule.size() > char_count)
             rule = std::vector<std::string>(rule.begin(), rule.begin() + char_count);
 
         std::vector<std::string> domain(rule.begin() + 2, rule.end());
 
         switch(op) {
-            case policy_op :: policy_add:
+            case policy_op::policy_add:
                 this->rm->AddLink(rule[0], rule[1], domain);
                 break;
-            case policy_op :: policy_remove:
+            case policy_op::policy_remove:
                 this->rm->DeleteLink(rule[0], rule[1], domain);
         }
     }
 }
 
-void Assertion :: BuildRoleLinks(std::shared_ptr<RoleManager> rm) {
+void Assertion::BuildRoleLinks(std::shared_ptr<RoleManager> rm) {
     this->rm = rm;
-    int char_count = int(count(this->value.begin(), this->value.end(), '_'));
+    size_t char_count = count(this->value.begin(), this->value.end(), '_');
 
     if (char_count < 2)
         throw IllegalArgumentException("the number of \"_\" in role definition should be at least 2");
 
-    for(int i = 0 ; i < this->policy.size() ; i++){
-        std::vector<std::string> rule = policy[i];
-
+    for(std::vector<std::string> rule : policy) {
         if (rule.size() < char_count)
             throw IllegalArgumentException("grouping policy elements do not meet role definition");
         if (rule.size() > char_count)
@@ -77,9 +74,9 @@ void Assertion :: BuildRoleLinks(std::shared_ptr<RoleManager> rm) {
     // df_logger.EnableLog(true);
 
     // Logger *logger = &df_logger;
-    // LogUtil :: SetLogger(*logger);
+    // LogUtil::SetLogger(*logger);
 
-    // LogUtil :: LogPrint("Role links for: " + Key);
+    // LogUtil::LogPrint("Role links for: " + Key);
 
     // this->rm->PrintRoles();
 }

--- a/casbin/model/assertion.h
+++ b/casbin/model/assertion.h
@@ -40,7 +40,7 @@ class Assertion {
         std::vector<std::vector<std::string>> policy;
         std::shared_ptr<RoleManager> rm;
 
-        void BuildIncrementalRoleLinks(std::shared_ptr<RoleManager> rm, policy_op op, std::vector<std::vector<std::string>> rules);
+        void BuildIncrementalRoleLinks(std::shared_ptr<RoleManager> rm, policy_op op, const std::vector<std::vector<std::string>>& rules);
 
         void BuildRoleLinks(std::shared_ptr<RoleManager> rm);
 };

--- a/casbin/model/function.cpp
+++ b/casbin/model/function.cpp
@@ -25,101 +25,103 @@
 
 namespace casbin {
 
-FunctionMap :: FunctionMap(){
+FunctionMap::FunctionMap(){
     scope = NULL;
 }
 
-void FunctionMap :: ProcessFunctions(std::string expression){
-    for(auto func: func_list){
-        int index = int(expression.find(func+"("));
+void FunctionMap::ProcessFunctions(const std::string& expression){
+    for(const std::string& func: func_list) {
+        size_t index = expression.find(func+"(");
 
         if (index != std::string::npos) {
-            int close_index = int(expression.find(")", index));
-            int start = index + int((func+"(").length());
+            size_t close_index = expression.find(")", index);
+            size_t start = index + func.length() + 1;
 
             std::string function_params = expression.substr(start, close_index - start);
             FetchIdentifier(this->scope, func);
             std::vector<std::string> params = Split(function_params, ",");
 
-            for(int i=0;i<params.size();i++){
-                int quote_index = int(params[i].find("\""));
+            for(std::string& param : params) {
+                size_t quote_index = param.find("\"");
+
                 if (quote_index == std::string::npos)
-                    Get(this->scope, Trim(params[i]));
-                else{
-                    params[i] = params[i].replace(quote_index, 1, "'");
-                    int second_quote_index = int(params[i].find("\"", quote_index+1));
-                    params[i] = params[i].replace(second_quote_index, 1, "'");
-                    Get(this->scope, Trim(params[i]));
+                    Get(this->scope, Trim(param));
+
+                else {
+                    param = param.replace(quote_index, 1, "'");
+                    size_t second_quote_index = param.find("\"", quote_index + 1);
+                    param = param.replace(second_quote_index, 1, "'");
+                    Get(this->scope, Trim(param));
                 }
             }
         }
     }
 }
 
-int FunctionMap :: GetRLen(){
+int FunctionMap::GetRLen(){
     bool found = FetchIdentifier(scope, "rlen");
     if(found)
         return GetInt(scope);
     return -1;
 }
 
-bool FunctionMap :: Evaluate(std::string expression){
+bool FunctionMap::Evaluate(const std::string& expression){
     ProcessFunctions(expression);
     return Eval(scope, expression);
 }
 
-bool FunctionMap :: GetBooleanResult(){
-    return bool(duk_get_boolean(scope, -1));
+bool FunctionMap::GetBooleanResult() {
+    return static_cast<bool>(duk_get_boolean(scope, -1));
 }
 
 // AddFunction adds an expression function.
-void FunctionMap :: AddFunction(std::string func_name, Function f, Index nargs) {
+void FunctionMap::AddFunction(const std::string& func_name, Function f, Index nargs) {
     func_list.push_back(func_name);
     PushFunction(scope, f, func_name, nargs);
 }
 
-void FunctionMap :: AddFunctionPropToR(std::string identifier, Function func, Index nargs){
+void FunctionMap::AddFunctionPropToR(const std::string& identifier, Function func, Index nargs){
     PushFunctionPropToObject(scope, "r", func, identifier, nargs);
 }
 
-void FunctionMap :: AddBooleanPropToR(std::string identifier, bool val){
+void FunctionMap::AddBooleanPropToR(const std::string& identifier, bool val){
     PushBooleanPropToObject(scope, "r", val, identifier);
 }
 
-void FunctionMap :: AddTruePropToR(std::string identifier){
+void FunctionMap::AddTruePropToR(const std::string& identifier){
     PushTruePropToObject(scope, "r", identifier);
 }
 
-void FunctionMap :: AddFalsePropToR(std::string identifier){
+void FunctionMap::AddFalsePropToR(const std::string& identifier){
     PushFalsePropToObject(scope, "r", identifier);
 }
 
-void FunctionMap :: AddIntPropToR(std::string identifier, int val){
+void FunctionMap::AddIntPropToR(const std::string& identifier, int val){
     PushIntPropToObject(scope, "r", val, identifier);
 }
 
-void FunctionMap :: AddFloatPropToR(std::string identifier, float val){
+void FunctionMap::AddFloatPropToR(const std::string& identifier, float val){
     PushFloatPropToObject(scope, "r", val, identifier);
 }
 
-void FunctionMap :: AddDoublePropToR(std::string identifier, double val){
+void FunctionMap::AddDoublePropToR(const std::string& identifier, double val){
     PushDoublePropToObject(scope, "r", val, identifier);
 }
 
-void FunctionMap :: AddStringPropToR(std::string identifier, std::string val){
+void FunctionMap::AddStringPropToR(const std::string& identifier, const std::string& val){
     PushStringPropToObject(scope, "r", val, identifier);
 }
 
-void FunctionMap :: AddPointerPropToR(std::string identifier, void* val){
+void FunctionMap::AddPointerPropToR(const std::string& identifier, void* val){
     PushPointerPropToObject(scope, "r", val, identifier);
 }
 
-void FunctionMap :: AddObjectPropToR(std::string identifier){
+void FunctionMap::AddObjectPropToR(const std::string& identifier){
     PushObjectPropToObject(scope, "r", identifier);
 }
 
 // LoadFunctionMap loads an initial function map.
-void FunctionMap :: LoadFunctionMap() {
+void FunctionMap::LoadFunctionMap() {
     AddFunction("keyMatch", KeyMatch, 2);
     AddFunction("keyMatch2", KeyMatch2, 2);
     AddFunction("keyMatch3", KeyMatch3, 2);

--- a/casbin/model/function.h
+++ b/casbin/model/function.h
@@ -30,36 +30,36 @@ class FunctionMap {
 
         FunctionMap();
 
-        void ProcessFunctions(std::string expression);
+        void ProcessFunctions(const std::string& expression);
 
         int GetRLen();
 
-        bool Evaluate(std::string expression);
+        bool Evaluate(const std::string& expression);
 
         bool GetBooleanResult();
 
         // AddFunction adds an expression function.
-        void AddFunction(std::string func_name, Function f, Index nargs);
+        void AddFunction(const std::string& func_name, Function f, Index nargs);
 
-        void AddFunctionPropToR(std::string identifier, Function func, Index nargs);
+        void AddFunctionPropToR(const std::string& identifier, Function func, Index nargs);
 
-        void AddBooleanPropToR(std::string identifier, bool val);
+        void AddBooleanPropToR(const std::string& identifier, bool val);
 
-        void AddTruePropToR(std::string identifier);
+        void AddTruePropToR(const std::string& identifier);
 
-        void AddFalsePropToR(std::string identifier);
+        void AddFalsePropToR(const std::string& identifier);
 
-        void AddIntPropToR(std::string identifier, int val);
+        void AddIntPropToR(const std::string& identifier, int val);
 
-        void AddFloatPropToR(std::string identifier, float val);
+        void AddFloatPropToR(const std::string& identifier, float val);
 
-        void AddDoublePropToR(std::string identifier, double val);
+        void AddDoublePropToR(const std::string& identifier, double val);
 
-        void AddStringPropToR(std::string identifier, std::string val);
+        void AddStringPropToR(const std::string& identifier, const std::string& val);
 
-        void AddPointerPropToR(std::string identifier, void* val);
+        void AddPointerPropToR(const std::string& identifier, void* val);
 
-        void AddObjectPropToR(std::string identifier);
+        void AddObjectPropToR(const std::string& identifier);
 
         // LoadFunctionMap loads an initial function map.
         void LoadFunctionMap();


### PR DESCRIPTION
Signed-off-by: Yash Pandey (YP) <yash.btech.cs19@iiitranchi.ac.in>

### Description

With reference to casbin/casbin-website#255, I tried to clean up the implementation of the model by reducing the numbers of constructor calls for `std::vector`, structured bindings and more.

### Points to note

This might not affect the actual performance of the enforcer directly, but is a valid and necessary cleanup.