### PR TITLE
feat: Added python bindings for `casbin::Enforcer`

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -42,7 +42,9 @@ if(UNIX)
 
     # If supported for the target machine, emit position-independent code
     # suitable for dynamic linking.
-    set_property(TARGET pycasbin PROPERTY POSITION_INDEPENDENT_CODE ON)
+    set_target_properties(pycasbin PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+    )
 endif()
 
 # macOS demands that the linker resolve all symbols at build time

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -14,12 +14,16 @@
 
 set(SOURCES
     main.cpp
+    py_enforcer.cpp
 )
 
 add_library(pycasbin MODULE ${SOURCES})
 
+target_include_directories(pycasbin PUBLIC ${CMAKE_SOURCE_DIR})
+
 set_target_properties(pycasbin PROPERTIES
     PREFIX ""
+    CXX_STANDARD 17
 )
 
 if(WIN32)
@@ -28,7 +32,7 @@ if(WIN32)
         SUFFIX ".pyd"
     )
 endif()
-    
+
 
 # NOTE: Depending of the compiler version pybind11 2.4.3 does not compile with C++17 so revert to c++11
 
@@ -53,5 +57,6 @@ target_link_libraries(pycasbin
     PRIVATE
         # casbin
         pybind11::module
+        casbin
 )
 

--- a/bindings/python/main.cpp
+++ b/bindings/python/main.cpp
@@ -27,31 +27,18 @@ int add(int i, int j) {
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(pycasbin, m) {
-    m.doc() = R"pbdoc(
-        Pybind11 example plugin
-        -----------------------
+// PYBIND11_MODULE(pycasbin, m) {
+//     m.doc() = R"pbdoc(
+//         Pybind11 example plugin
+//         -----------------------
 
-        .. currentmodule:: pycasbin
+//         .. currentmodule:: pycasbin
 
-        .. autosummary::
-           :toctree: _generate
+//         .. autosummary::
+//            :toctree: _generate
 
-           add
-           subtract
-    )pbdoc";
+//            Enforcer
+//     )pbdoc";
 
-    m.def("add", &add, R"pbdoc(
-        Add two numbers
-
-        Some other explanation about the add function.
-    )pbdoc");
-
-    m.def("subtract", [](int i, int j) { return i - j; }, R"pbdoc(
-        Subtract two numbers
-
-        Some other explanation about the subtract function.
-    )pbdoc");
-
-    m.attr("__version__") = "dev";
-}
+//     m.attr("__version__") = "dev";
+// }

--- a/bindings/python/py_enforcer.cpp
+++ b/bindings/python/py_enforcer.cpp
@@ -1,0 +1,148 @@
+/*
+* Copyright 2021 The casbin Authors. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <casbin/casbin.h>
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(pycasbin, m) {
+    py::class_<casbin::Enforcer>(m, "Enforcer")
+        .def(py::init<>())
+        .def(py::init<const std::string &, const std::string &>())
+        .def(py::init<const std::string &, std::shared_ptr<casbin::Adapter>>())
+        .def(py::init<std::shared_ptr<casbin::Model>, std::shared_ptr<casbin::Adapter>>())
+        .def(py::init<std::shared_ptr<casbin::Model>>())
+        .def(py::init<const std::string &>())
+        .def(py::init<const std::string &, const std::string &, bool>())
+        .def("InitWithFile", &casbin::Enforcer::InitWithFile, "InitWithFile initializes an enforcer with a model file and a policy file.")
+        .def("InitWithAdapter", &casbin::Enforcer::InitWithAdapter, "InitWithAdapter initializes an enforcer with a database adapter.")
+        .def("InitWithModelAndAdapter", &casbin::Enforcer::InitWithModelAndAdapter, "InitWithModelAndAdapter initializes an enforcer with a model and a database adapter.")
+        .def("Initialize", &casbin::Enforcer::Initialize)
+        .def("LoadModel", &casbin::Enforcer::LoadModel, R"doc(
+            LoadModel reloads the model from the model CONF file.
+            Because the policy is attached to a model, so the policy is invalidated and 
+            needs to be reloaded by calling LoadPolicy().
+        )doc")
+        .def("GetModel", &casbin::Enforcer::GetModel, "GetModel gets the current model.")
+        .def("SetModel", &casbin::Enforcer::SetModel, "SetModel sets the current model.")
+        .def("GetAdapter", &casbin::Enforcer::GetAdapter, "GetAdapter gets the current adapter.")
+        .def("SetAdapter", &casbin::Enforcer::SetAdapter, "SetAdapter sets the current adapter.")
+        .def("SetWatcher", &casbin::Enforcer::SetWatcher, "SetWatcher sets the current watcher.")
+        .def("GetRoleManager", &casbin::Enforcer::GetRoleManager, "GetRoleManager gets the current role manager.")
+        .def("SetRoleManager", &casbin::Enforcer::SetRoleManager, "SetRoleManager sets the current role manager.")
+        .def("SetEffector", &casbin::Enforcer::SetEffector, "SetEffector sets the current effector.")
+        .def("ClearPolicy", &casbin::Enforcer::ClearPolicy, "ClearPolicy clears all policy.")
+        .def("LoadPolicy", &casbin::Enforcer::LoadPolicy, "LoadPolicy reloads the policy from file/database.")
+        // .def("LoadFilteredPolicy", &casbin::Enforcer::LoadFilteredPolicy, "LoadFilteredPolicy reloads a filtered policy from file/database.")
+        .def("IsFiltered", &casbin::Enforcer::IsFiltered, "IsFiltered returns true if the loaded policy has been filtered.")
+        .def("SavePolicy", &casbin::Enforcer::SavePolicy, "SavePolicy saves the current policy (usually after changed with Casbin API) back to file/database.")
+        .def("EnableEnforce", &casbin::Enforcer::EnableEnforce, "EnableEnforce changes the enforcing state of Casbin, when Casbin is disabled, all access will be allowed by the Enforce() function.")
+        .def("EnableLog", &casbin::Enforcer::EnableLog, "EnableLog changes whether Casbin will log messages to the Logger.")
+        .def("EnableAutoNotifyWatcher", &casbin::Enforcer::EnableAutoNotifyWatcher, "EnableAutoNotifyWatcher controls whether to save a policy rule automatically notify the Watcher when it is added or removed.")
+        .def("EnableAutoSave", &casbin::Enforcer::EnableAutoSave, "EnableAutoSave controls whether to save a policy rule automatically to the adapter when it is added or removed.")
+        .def("EnableAutoBuildRoleLinks", &casbin::Enforcer::EnableAutoBuildRoleLinks, "EnableAutoBuildRoleLinks controls whether to rebuild the role inheritance relations when a role is added or deleted.")
+        .def("BuildRoleLinks", &casbin::Enforcer::BuildRoleLinks, "BuildRoleLinks manually rebuild the role inheritance relations.")
+        .def("BuildIncrementalRoleLinks", &casbin::Enforcer::BuildIncrementalRoleLinks, "BuildIncrementalRoleLinks provides incremental build the role inheritance relations.")
+        // .def("Enforce", py::overload_cast<casbin::Scope>(&casbin::Enforcer::Enforce), "Enforce decides whether a \"subject\" can access a \"object\" with the operation \"action\", input parameters are usually: (sub, obj, act).")
+        .def("Enforce", py::overload_cast<const casbin::DataList &>(&casbin::Enforcer::Enforce), "Enforce with a vector param,decides whether a \"subject\" can access a \"object\" with the operation \"action\", input parameters are usually: (sub, obj, act).")
+        .def("Enforce", py::overload_cast<const casbin::DataMap &>(&casbin::Enforcer::Enforce), "Enforce with a map param, decides whether a \"subject\" can access a \"object\" with the operation \"action\", input parameters are usually: (sub, obj, act).")
+        // .def("EnforceWithMatcher", py::overload_cast<const std::string &, casbin::Scope>(&casbin::Enforcer::EnforceWithMatcher), "EnforceWithMatcher use a custom matcher to decides whether a \"subject\" can access a \"object\" with the operation \"action\", input parameters are usually: (matcher, sub, obj, act), use model matcher by default when matcher is \"\".")
+        .def("EnforceWithMatcher", py::overload_cast<const std::string &, const casbin::DataList &>(&casbin::Enforcer::EnforceWithMatcher), "EnforceWithMatcher use a custom matcher to decides whether a \"subject\" can access a \"object\" with the operation \"action\", input parameters are usually: (matcher, sub, obj, act), use model matcher by default when matcher is \"\".")
+        .def("EnforceWithMatcher", py::overload_cast<const std::string &, const casbin::DataMap &>(&casbin::Enforcer::EnforceWithMatcher), "EnforceWithMatcher use a custom matcher to decides whether a \"subject\" can access a \"object\" with the operation \"action\", input parameters are usually: (matcher, sub, obj, act), use model matcher by default when matcher is \"\".")
+        .def("BatchEnforce", &casbin::Enforcer::BatchEnforce, "BatchEnforce enforce in batches")
+        .def("BatchEnforceWithMatcher", &casbin::Enforcer::BatchEnforceWithMatcher, "BatchEnforceWithMatcher enforce with matcher in batches")
+
+        /* Management API member functions. */
+
+        .def("GetAllSubjects", &casbin::Enforcer::GetAllSubjects)
+        .def("GetAllNamedSubjects", &casbin::Enforcer::GetAllNamedSubjects)
+        .def("GetAllObjects", &casbin::Enforcer::GetAllObjects)
+        .def("GetAllNamedObjects", &casbin::Enforcer::GetAllNamedObjects)
+        .def("GetAllActions", &casbin::Enforcer::GetAllActions)
+        .def("GetAllNamedActions", &casbin::Enforcer::GetAllNamedActions)
+        .def("GetAllRoles", &casbin::Enforcer::GetAllRoles)
+        .def("GetAllNamedRoles", &casbin::Enforcer::GetAllNamedRoles)
+        .def("GetPolicy", &casbin::Enforcer::GetPolicy)
+        .def("GetFilteredPolicy", &casbin::Enforcer::GetFilteredPolicy)
+        .def("GetNamedPolicy", &casbin::Enforcer::GetNamedPolicy)
+        .def("GetFilteredNamedPolicy", &casbin::Enforcer::GetFilteredNamedPolicy)
+        .def("GetGroupingPolicy", &casbin::Enforcer::GetGroupingPolicy)
+        .def("GetFilteredGroupingPolicy", &casbin::Enforcer::GetFilteredGroupingPolicy)
+        .def("GetNamedGroupingPolicy", &casbin::Enforcer::GetNamedGroupingPolicy)
+        .def("GetFilteredNamedGroupingPolicy", &casbin::Enforcer::GetFilteredNamedGroupingPolicy)
+
+        .def("HasPolicy", &casbin::Enforcer::HasPolicy)
+        .def("HasNamedPolicy", &casbin::Enforcer::HasNamedPolicy)
+        .def("AddPolicy", &casbin::Enforcer::AddPolicy)
+        .def("AddNamedPolicy", &casbin::Enforcer::AddNamedPolicy)
+        .def("AddNamedPolicies", &casbin::Enforcer::AddNamedPolicies)
+        .def("RemovePolicy", &casbin::Enforcer::RemovePolicy)
+        .def("RemovePolicies", &casbin::Enforcer::RemovePolicies)
+        .def("RemoveFilteredPolicy", &casbin::Enforcer::RemoveFilteredPolicy)
+        .def("RemoveNamedPolicies", &casbin::Enforcer::RemoveNamedPolicies)
+        .def("RemoveFilteredNamedPolicy", &casbin::Enforcer::RemoveFilteredNamedPolicy)
+        .def("HasNamedGroupingPolicy", &casbin::Enforcer::HasNamedGroupingPolicy)
+        .def("AddGroupingPolicy", &casbin::Enforcer::AddGroupingPolicy)
+        .def("AddGroupingPolicies", &casbin::Enforcer::AddGroupingPolicies)
+        .def("AddNamedGroupingPolicy", &casbin::Enforcer::AddNamedGroupingPolicy)
+        .def("AddNamedGroupingPolicies", &casbin::Enforcer::AddNamedGroupingPolicies)
+        .def("RemoveGroupingPolicy", &casbin::Enforcer::RemoveGroupingPolicy)
+        .def("RemoveGroupingPolicies", &casbin::Enforcer::RemoveGroupingPolicies)
+        .def("RemoveFilteredGroupingPolicy", &casbin::Enforcer::RemoveFilteredGroupingPolicy)
+        .def("RemoveNamedGroupingPolicy", &casbin::Enforcer::RemoveNamedGroupingPolicy)
+        .def("RemoveNamedGroupingPolicies", &casbin::Enforcer::RemoveNamedGroupingPolicies)
+        .def("RemoveFilteredNamedGroupingPolicy", &casbin::Enforcer::RemoveFilteredNamedGroupingPolicy)
+        .def("AddFunction", &casbin::Enforcer::AddFunction)
+        .def("UpdateGroupingPolicy", &casbin::Enforcer::UpdateGroupingPolicy)
+        .def("UpdateNamedGroupingPolicy", &casbin::Enforcer::UpdateNamedGroupingPolicy)
+        .def("UpdatePolicy", &casbin::Enforcer::UpdatePolicy)
+        .def("UpdateNamedPolicy", &casbin::Enforcer::UpdateNamedPolicy)
+        .def("UpdatePolicies", &casbin::Enforcer::UpdatePolicies)
+        .def("UpdateNamedPolicies", &casbin::Enforcer::UpdateNamedPolicies)
+
+        /* RBAC API member functions. */
+
+        .def("GetRolesForUser", &casbin::Enforcer::GetRolesForUser)
+        .def("GetUsersForRole", &casbin::Enforcer::GetUsersForRole)
+        .def("HasRoleForUser", &casbin::Enforcer::HasRoleForUser)
+        .def("AddRoleForUser", &casbin::Enforcer::AddRoleForUser)
+        .def("AddRolesForUser", &casbin::Enforcer::AddRolesForUser)
+        .def("AddPermissionForUser", &casbin::Enforcer::AddPermissionForUser)
+        .def("DeletePermissionForUser", &casbin::Enforcer::DeletePermissionForUser)
+        .def("DeletePermissionsForUser", &casbin::Enforcer::DeletePermissionsForUser)
+        .def("GetPermissionsForUser", &casbin::Enforcer::GetPermissionsForUser)
+        .def("HasPermissionForUser", &casbin::Enforcer::HasPermissionForUser)
+        .def("GetImplicitRolesForUser", &casbin::Enforcer::GetImplicitRolesForUser)
+        .def("GetImplicitPermissionsForUser", &casbin::Enforcer::GetImplicitPermissionsForUser)
+        .def("GetImplicitUsersForPermission", &casbin::Enforcer::GetImplicitUsersForPermission)
+        .def("DeleteRoleForUser", &casbin::Enforcer::DeleteRoleForUser)
+        .def("DeleteRolesForUser", &casbin::Enforcer::DeleteRolesForUser)
+        .def("DeleteUser", &casbin::Enforcer::DeleteUser)
+        .def("DeleteRole", &casbin::Enforcer::DeleteRole)
+        .def("DeletePermission", &casbin::Enforcer::DeletePermission)
+
+        /* Internal API member functions omitted */
+
+        /* RBAC API with domains.*/
+
+        .def("GetUsersForRoleInDomain", &casbin::Enforcer::GetUsersForRoleInDomain)
+        .def("GetRolesForUserInDomain", &casbin::Enforcer::GetRolesForUserInDomain)
+        .def("GetPermissionsForUserInDomain", &casbin::Enforcer::GetPermissionsForUserInDomain)
+        .def("AddRoleForUserInDomain", &casbin::Enforcer::AddRoleForUserInDomain)
+        .def("DeleteRoleForUserInDomain", &casbin::Enforcer::DeleteRoleForUserInDomain);
+}

--- a/casbin/CMakeLists.txt
+++ b/casbin/CMakeLists.txt
@@ -24,11 +24,17 @@ target_precompile_headers(casbin PUBLIC "pch.h")
 
 set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR})
 
-set_target_properties(casbin PROPERTIES PREFIX "")
+set_target_properties(casbin PROPERTIES 
+    PREFIX ""
+)
+
 if(WIN32 OR MSVC)
     set_target_properties(casbin PROPERTIES SUFFIX ".lib")
 elseif(UNIX)
-    set_target_properties(casbin PROPERTIES SUFFIX ".a")
+    set_target_properties(casbin PROPERTIES 
+        SUFFIX ".a"
+        POSITION_INDEPENDENT_CODE ON
+    )
 endif()
 
 install(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,21 +15,27 @@
 if(CASBIN_BUILD_TEST)
   set(CMAKE_CXX_STANDARD 17)
 
-add_executable(
-  casbintest
-  built_in_functions_test.cpp
-  config_test.cpp
-  enforcer_test.cpp
-  enforcer_cached_test.cpp
-  enforcer_synced_test.cpp
-  management_api_test.cpp
-  model_enforcer_test.cpp
-  model_test.cpp
-  rbac_api_with_domains_test.cpp
-  rbac_api_test.cpp
-  role_manager_test.cpp
-  util_test.cpp
-)
+  add_executable(
+    casbintest
+    built_in_functions_test.cpp
+    config_test.cpp
+    enforcer_test.cpp
+    enforcer_cached_test.cpp
+    enforcer_synced_test.cpp
+    management_api_test.cpp
+    model_enforcer_test.cpp
+    model_test.cpp
+    rbac_api_with_domains_test.cpp
+    rbac_api_test.cpp
+    role_manager_test.cpp
+    util_test.cpp
+  )
+
+  if(UNIX)
+    set_target_properties(casbintest PROPERTIES
+      POSITION_INDEPENDENT_CODE ON
+    )
+  endif()
 
   target_include_directories(casbintest PUBLIC ${CMAKE_SOURCE_DIR})
 

--- a/tests/benchmarks/CMakeLists.txt
+++ b/tests/benchmarks/CMakeLists.txt
@@ -23,6 +23,12 @@ add_executable(casbin_benchmark
 
 target_include_directories(casbin_benchmark PUBLIC ${CMAKE_SOURCE_DIR})
 
+if(UNIX)
+    set_target_properties(casbin_benchmark PROPERTIES
+      POSITION_INDEPENDENT_CODE ON
+    )
+endif()
+
 target_link_libraries(
     casbin_benchmark
     benchmark


### PR DESCRIPTION
## Fixes #84 partially
Signed-off-by: Yash Pandey (YP) <yash.btech.cs19@iiitranchi.ac.in>

---

### Description

This code:

- Adds `casbin::Enforcer` definitions in python bindings.
    - The bindings are compiled into `pycasbin.so` file in UNIX and `pycasbin.pyd` in Windows.
    - This file can now be added into the PATH variable and can be imported directly in Python.
- Configures the build system to compile targets with `-fPIC` flag