### PR TITLE
feat: Added bindings for `CachedEnforcer`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(CMAKE_MODULE_PATH
 )
 
 set(CMAKE_WARN_DEPRECATED ON)
+set(PY_CASBIN_VERSION 1.0)
 
 if(APPLE AND NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
     # The value of this variable should be set prior to the first project() command invocation

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -31,6 +31,8 @@ set_target_properties(pycasbin PROPERTIES
     CXX_STANDARD 17
 )
 
+add_definitions(-DPY_CASBIN_VERSION=${PY_CASBIN_VERSION})
+
 if(WIN32)
     # Windows uses .pyd extension for python modules
     set_target_properties(pycasbin PROPERTIES

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -14,10 +14,15 @@
 
 set(SOURCES
     main.cpp
+    py_cached_enforcer.cpp
     py_enforcer.cpp
 )
 
-add_library(pycasbin MODULE ${SOURCES})
+set(HEADERS
+    py_casbin.h
+)
+
+add_library(pycasbin MODULE ${SOURCES} ${HEADERS})
 
 target_include_directories(pycasbin PUBLIC ${CMAKE_SOURCE_DIR})
 

--- a/bindings/python/main.cpp
+++ b/bindings/python/main.cpp
@@ -37,5 +37,5 @@ PYBIND11_MODULE(pycasbin, m) {
     bindPyEnforcer(m);
     bindPyCachedEnforcer(m);
 
-    m.attr("__version__") = "dev";
+    m.attr("__version__") = PY_CASBIN_VERSION;
 }

--- a/bindings/python/py_cached_enforcer.cpp
+++ b/bindings/python/py_cached_enforcer.cpp
@@ -12,30 +12,15 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*
-* This is the main file for python bindings workflow
 */
 
 #include <pybind11/pybind11.h>
-#include "py_casbin.h"
+#include <pybind11/stl.h>
+#include <casbin/casbin.h>
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(pycasbin, m) {
-    m.doc() = R"pbdoc(
-        Casbin Authorization Library
-        -----------------------
-
-        .. currentmodule:: pycasbin
-
-        .. autosummary::
-           :toctree: _generate
-
-           Enforcer
-    )pbdoc";
-
-    bindPyEnforcer(m);
-    bindPyCachedEnforcer(m);
-
-    m.attr("__version__") = "dev";
+void bindPyCachedEnforcer(py::module &m) {
+    py::class_<casbin::CachedEnforcer>(m, "CachedEnforcer")
+        .def(py::init<>());
 }

--- a/bindings/python/py_cached_enforcer.cpp
+++ b/bindings/python/py_cached_enforcer.cpp
@@ -21,6 +21,67 @@
 namespace py = pybind11;
 
 void bindPyCachedEnforcer(py::module &m) {
-    py::class_<casbin::CachedEnforcer>(m, "CachedEnforcer")
-        .def(py::init<>());
+    py::class_<casbin::CachedEnforcer, casbin::Enforcer>(m, "CachedEnforcer")
+        .def(py::init<>(), "Enforcer is the default constructor.")
+        .def(py::init<const std::string &, const std::string &>(), R"doc(
+            Enforcer initializes an enforcer with a model file and a policy file.
+            @param model_path the path of the model file.
+            @param policy_file the path of the policy file.
+        )doc")
+        .def(py::init<const std::string &, std::shared_ptr<casbin::Adapter>>(), R"doc(
+            Enforcer initializes an enforcer with a database adapter.
+            @param model_path the path of the model file.
+            @param adapter the adapter.
+        )doc")
+        .def(py::init<std::shared_ptr<casbin::Model>, std::shared_ptr<casbin::Adapter>>(), R"doc(
+            Enforcer initializes an enforcer with a model and a database adapter.
+            @param m the model.
+            @param adapter the adapter.
+        )doc")
+        .def(py::init<std::shared_ptr<casbin::Model>>(), R"doc(
+            Enforcer initializes an enforcer with a model.
+            @param m the model.
+        )doc")
+        .def(py::init<const std::string &>(), R"doc(
+            Enforcer initializes an enforcer with a model file.
+            @param model_path the path of the model file.
+        )doc")
+        .def(py::init<const std::string &, const std::string &, bool>(), R"doc(
+            Enforcer initializes an enforcer with a model file, a policy file and an enable log flag.
+            @param model_path the path of the model file.
+            @param policy_file the path of the policy file.
+            @param enable_log whether to enable Casbin's log.
+        )doc")
+
+        // .def("Enforce", py::overload_cast<casbin::Scope>(&casbin::CachedEnforcer::Enforce), R"doc(
+        //     Enforce with a vector param,decides whether a "subject" can access a
+        //     "object" with the operation "action", input parameters are usually: (sub,
+        //     obj, act).
+        // )doc")
+        .def("Enforce", py::overload_cast<const casbin::DataList &>(&casbin::CachedEnforcer::Enforce), R"doc(
+            Enforce with a map param,decides whether a "subject" can access a "object"
+            with the operation "action", input parameters are usually: (sub, obj, act).
+        )doc")
+        .def("Enforce", py::overload_cast<const casbin::DataMap &>(&casbin::CachedEnforcer::Enforce), R"doc(
+            Enforce with a map param,decides whether a "subject" can access a "object"
+            with the operation "action", input parameters are usually: (sub, obj, act).
+        )doc")
+        // .def("EnforceWithMatcher", py::overload_cast<const std::string &, casbin::Scope>(&casbin::CachedEnforcer::EnforceWithMatcher), R"doc(
+        //     EnforceWithMatcher use a custom matcher to decides whether a "subject" can
+        //     access a "object" with the operation "action", input parameters are
+        //     usually: (matcher, sub, obj, act), use model matcher by default when
+        //     matcher is "".
+        // )doc")
+        .def("EnforceWithMatcher", py::overload_cast<const std::string &, const casbin::DataList &>(&casbin::CachedEnforcer::EnforceWithMatcher), R"doc(
+            EnforceWithMatcher use a custom matcher to decides whether a "subject" can
+            access a "object" with the operation "action", input parameters are
+            usually: (matcher, sub, obj, act), use model matcher by default when
+            matcher is "".
+        )doc")
+        .def("EnforceWithMatcher", py::overload_cast<const std::string &, const casbin::DataMap &>(&casbin::CachedEnforcer::EnforceWithMatcher), R"doc(
+            EnforceWithMatcher use a custom matcher to decides whether a "subject" can
+            access a "object" with the operation "action", input parameters are
+            usually: (matcher, sub, obj, act), use model matcher by default when
+            matcher is "".
+        )doc");
 }

--- a/bindings/python/py_casbin.h
+++ b/bindings/python/py_casbin.h
@@ -12,30 +12,11 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*
-* This is the main file for python bindings workflow
 */
 
 #include <pybind11/pybind11.h>
-#include "py_casbin.h"
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(pycasbin, m) {
-    m.doc() = R"pbdoc(
-        Casbin Authorization Library
-        -----------------------
-
-        .. currentmodule:: pycasbin
-
-        .. autosummary::
-           :toctree: _generate
-
-           Enforcer
-    )pbdoc";
-
-    bindPyEnforcer(m);
-    bindPyCachedEnforcer(m);
-
-    m.attr("__version__") = "dev";
-}
+void bindPyEnforcer(py::module &m);
+void bindPyCachedEnforcer(py::module &m);

--- a/bindings/python/py_enforcer.cpp
+++ b/bindings/python/py_enforcer.cpp
@@ -18,9 +18,11 @@
 #include <pybind11/stl.h>
 #include <casbin/casbin.h>
 
+#include "py_casbin.h"
+
 namespace py = pybind11;
 
-PYBIND11_MODULE(pycasbin, m) {
+void bindPyEnforcer(py::module& m) {
     py::class_<casbin::Enforcer>(m, "Enforcer")
         .def(py::init<>())
         .def(py::init<const std::string &, const std::string &>())

--- a/casbin/enforcer_cached.h
+++ b/casbin/enforcer_cached.h
@@ -38,9 +38,9 @@ public:
     void InvalidateCache();
 
 public:
-    /**
+     /**
          * Enforcer is the default constructor.
-         */
+     */
     CachedEnforcer();
     /**
          * Enforcer initializes an enforcer with a model file and a policy file.


### PR DESCRIPTION
## Fixes #84 partially

Signed-off-by: Yash Pandey (YP) <yash.btech.cs19@iiitranchi.ac.in>

---

### Description

This code:
- Adds bindings for `casbin::CachedEnforcer`
    - The methods added are only the constructors and overrides
    - The rest of the methods are inherited from `casbin::Enforcer` just like the C++ implementation.
- Adds versioning to `pycasbin` module through CMake configuration.
- Refactors the workflow by passing the reference of the `py::module` object to functions.
    - Each function then defines a binding for all the methods present in the corresponding C++ translation unit.

### Important Note

When I try to build the `pycasbin` target, it throws an error wherever there is an occurrence of `casbin::Scope` in the binding definition. Considering the fact that pycasbin is a client-centric interface, exposing `casbin::Scope` is redundant, so I dropped the support for Scope in pycasbin.
