### PR TITLE
fix: compile error on some environments

### DIFF
--- a/casbin/enforcer_interface.h
+++ b/casbin/enforcer_interface.h
@@ -17,6 +17,7 @@
 #ifndef CASBIN_CPP_ENFORCER_INTERFACE
 #define CASBIN_CPP_ENFORCER_INTERFACE
 
+#include "./data_types.h"
 #include "./model/model.h"
 #include "./persist/adapter.h"
 #include "./persist/default_watcher.h"


### PR DESCRIPTION
Hi,

I was getting compile errors on CentOS 8 and gcc 10.3.0 with bazel.

https://paste.ubuntu.com/p/W5Jj48sKpD/

Adding this line of #include fixes the issue.