### PR TITLE
feat: Added bindings for `casbin::Model`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -359,3 +359,4 @@ MigrationBackup/
 
 # CMake work directory
 cmake-build/
+xcode-build/

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES
     py_cached_enforcer.cpp
     py_enforcer.cpp
     py_abac_data.cpp
+    py_model.cpp
 )
 
 set(HEADERS
@@ -65,7 +66,6 @@ endif()
 
 target_link_libraries(pycasbin
     PRIVATE
-        # casbin
         pybind11::module
         casbin
 )

--- a/bindings/python/main.cpp
+++ b/bindings/python/main.cpp
@@ -37,6 +37,7 @@ PYBIND11_MODULE(pycasbin, m) {
     bindPyEnforcer(m);
     bindPyCachedEnforcer(m);
     bindABACData(m);
+    bindPyModel(m);
 
     m.attr("__version__") = PY_CASBIN_VERSION;
 }

--- a/bindings/python/py_casbin.h
+++ b/bindings/python/py_casbin.h
@@ -21,3 +21,4 @@ namespace py = pybind11;
 void bindPyEnforcer(py::module &m);
 void bindPyCachedEnforcer(py::module &m);
 void bindABACData(py::module &m);
+void bindPyModel(py::module &m);

--- a/bindings/python/py_model.cpp
+++ b/bindings/python/py_model.cpp
@@ -1,0 +1,55 @@
+/*
+* Copyright 2021 The casbin Authors. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <casbin/casbin.h>
+
+#include "py_casbin.h"
+
+void bindPyModel(py::module &m) {
+    py::class_<casbin::Model>(m, "Model")
+        .def(py::init<>())
+        .def(py::init<const std::string &>())
+
+        .def("HasSection", &casbin::Model::HasSection)
+        .def("AddDef", &casbin::Model::AddDef, "AddDef adds an assertion to the model.")
+        .def("LoadModel", &casbin::Model::LoadModel, "LoadModel loads the model from model CONF file.")
+        .def("LoadModelFromText", &casbin::Model::LoadModelFromText, "LoadModelFromText loads the model from the text.")
+        .def("LoadModelFromConfig", &casbin::Model::LoadModelFromConfig)
+        .def("PrintModel", &casbin::Model::PrintModel, "PrintModel prints the model to the log.")
+
+        .def("BuildIncrementalRoleLinks", &casbin::Model::BuildIncrementalRoleLinks)
+        .def("BuildRoleLinks", &casbin::Model::BuildRoleLinks, "BuildRoleLinks initializes the roles in RBAC.")
+        .def("PrintPolicy", &casbin::Model::PrintPolicy, "PrintPolicy prints the policy to log.")
+        .def("ClearPolicy", &casbin::Model::ClearPolicy, "ClearPolicy clears all current policy.")
+        .def("GetPolicy", &casbin::Model::GetPolicy, "GetPolicy gets all rules in a policy.")
+        .def("GetFilteredPolicy", &casbin::Model::GetFilteredPolicy, "GetFilteredPolicy gets rules based on field filters from a policy.")
+        .def("HasPolicy", &casbin::Model::HasPolicy, "HasPolicy determines whether a model has the specified policy rule.")
+        .def("AddPolicy", &casbin::Model::AddPolicy, "AddPolicy adds a policy rule to the model.")
+        .def("AddPolicies", &casbin::Model::AddPolicies, "AddPolicies adds policy rules to the model.")
+        .def("UpdatePolicy", &casbin::Model::UpdatePolicy, "UpdatePolicy updates a policy rule from the model.")
+        .def("UpdatePolicies", &casbin::Model::UpdatePolicies, "UpdatePolicies updates a set of policy rules from the model.")
+        .def("RemovePolicy", &casbin::Model::RemovePolicy, "RemovePolicy removes a policy rule from the model.")
+        .def("RemovePolicies", &casbin::Model::RemovePolicies, "RemovePolicies removes policy rules from the model.")
+        .def("RemoveFilteredPolicy", &casbin::Model::RemoveFilteredPolicy, "RemoveFilteredPolicy removes policy rules based on field filters from the model.")
+        .def("GetValuesForFieldInPolicy", &casbin::Model::GetValuesForFieldInPolicy, "GetValuesForFieldInPolicy gets all values for a field for all rules in a policy, duplicated values are removed.")
+        .def("GetValuesForFieldInPolicyAllTypes", &casbin::Model::GetValuesForFieldInPolicyAllTypes, "GetValuesForFieldInPolicyAllTypes gets all values for a field for all rules in a policy of all p_types, duplicated values are removed.")
+
+        .def_static("NewModel", &casbin::Model::NewModel, "NewModel creates an empty model.")
+        .def_static("NewModelFromFile", &casbin::Model::NewModelFromFile, "NewModelFromFile creates a model from a .CONF file.")
+        .def_static("NewModelFromString", &casbin::Model::NewModelFromString, "NewModel creates a model from a std::string which contains model text.");
+}

--- a/tests/python/test_model.py
+++ b/tests/python/test_model.py
@@ -12,29 +12,21 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import pycasbin as casbin
+from config_path import *
 import unittest
-import sys
-import os
-import pycasbin
-import test_enforcer
-import test_model
 
-def suite():
+class TestModel(unittest.TestCase):
+    def test_NewModel(self):
+        model = casbin.Model.NewModel()
+        self.assertIsNotNone(model)
 
-    # top level directory cached on loader instance
-    suite = unittest.TestSuite()
-    loader = unittest.TestLoader()
+    def test_NewModelFromFile(self):
+        model = casbin.Model.NewModelFromFile(basic_model_path)
+        self.assertIsNotNone(model)
 
-    suite.addTest(loader.loadTestsFromModule(test_enforcer))
-    suite.addTest(loader.loadTestsFromModule(test_model))
-
-    return suite
-
-
-if __name__ == '__main__':
-    runner = unittest.TextTestRunner(verbosity=2)
-    test_suite = suite()
-    result = runner.run(test_suite)
-    if result.wasSuccessful() == False:
-        sys.exit(1)
-    sys.exit(0)
+    # def test_NewModelFromString(self):
+    #     with open(basic_model_path, 'r') as model_file:
+    #         model_string = model_file.read().replace('\n', '')
+    #     model = casbin.Model.NewModelFromString(model_string)
+    #     self.assertIsNotNone(model)


### PR DESCRIPTION
## Fixes #84

Signed-off-by: Yash Pandey (YP) <yash.btech.cs19@iiitranchi.ac.in>

---

### Description

This code:

- Adds python bindings for `casbin::Model`.
- Adds the support for calling static member functions of `casbin::Model` in python.
- Adds unit tests in python for the bindings.
- Configures the build system and pybind workflow to include `py_model.cpp`