### PR TITLE
feat: Added `config_path` for test entities

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,8 +15,9 @@
 if(CASBIN_BUILD_TEST)
   set(CMAKE_CXX_STANDARD 17)
 
-  add_executable(
-    casbintest
+  add_definitions(-DCASBIN_PROJECT_DIR=${CMAKE_SOURCE_DIR})
+
+  set(CASBIN_TEST_SOURCE
     built_in_functions_test.cpp
     config_test.cpp
     enforcer_test.cpp
@@ -30,6 +31,12 @@ if(CASBIN_BUILD_TEST)
     role_manager_test.cpp
     util_test.cpp
   )
+
+  set(CASBIN_TEST_HEADER
+    config_path.h
+  )
+
+  add_executable(casbintest ${CASBIN_TEST_SOURCE} ${CASBIN_TEST_HEADER})
 
   if(UNIX)
     set_target_properties(casbintest PROPERTIES

--- a/tests/benchmarks/CMakeLists.txt
+++ b/tests/benchmarks/CMakeLists.txt
@@ -12,14 +12,21 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-add_executable(casbin_benchmark
-    config_path.h
+add_definitions(-DCASBIN_PROJECT_DIR=${CMAKE_SOURCE_DIR})
+
+set(CASBIN_BENCHMARK_SOURCE
     main.cpp
     model_b.cpp
     enforcer_cached_b.cpp
     management_api_b.cpp
     role_manager_b.cpp
 )
+
+set(CASBIN_HEADER
+    config_path.h
+)
+
+add_executable(casbin_benchmark ${CASBIN_BENCHMARK_SOURCE} ${CASBIN_HEADER})
 
 target_include_directories(casbin_benchmark PUBLIC ${CMAKE_SOURCE_DIR})
 

--- a/tests/benchmarks/enforcer_cached_b.cpp
+++ b/tests/benchmarks/enforcer_cached_b.cpp
@@ -135,7 +135,7 @@ BENCHMARK(BenchmarkCachedRBACModelWithDomains);
 
 // ---- TODO ----
 // static void BenchmarkCachedABACModel(benchmark::State& state) {
-//     casbin::CachedEnforcer e("examples/abac_model.conf", false);
+//     casbin::CachedEnforcer e(abac_model_path, false);
 //     auto data1 = casbin::GetData({
 //         {"Name", "data1"},
 //         {"Owner", "alice"}

--- a/tests/config_path.h
+++ b/tests/config_path.h
@@ -25,13 +25,24 @@ static const std::string relative_path = STRINGIFY(CASBIN_PROJECT_DIR);
 
 static const std::string basic_model_path = relative_path + "/examples/basic_model.conf";
 static const std::string basic_policy_path = relative_path + "/examples/basic_policy.csv";
+static const std::string basic_model_without_spaces_path = relative_path + "/examples/basic_model_without_spaces.conf";
+static const std::string basic_without_users_model_path = relative_path + "/examples/basic_without_users_model.conf";
+static const std::string basic_without_users_policy_path = relative_path + "/examples/basic_without_users_policy.csv";
+static const std::string basic_without_resources_model_path = relative_path + "/examples/basic_without_resources_model.conf";
+static const std::string basic_without_resources_policy_path = relative_path + "/examples/basic_without_resources_policy.csv";
+static const std::string basic_with_root_model_path = relative_path + "/examples/basic_with_root_model.conf";
 
+static const std::string rbac_with_not_deny_model_path = relative_path + "/examples/rbac_with_not_deny_model.conf";
 static const std::string rbac_model_path = relative_path + "/examples/rbac_model.conf";
 static const std::string rbac_policy_path = relative_path + "/examples/rbac_policy.csv";
 static const std::string rbac_with_resource_roles_model_path = relative_path + "/examples/rbac_with_resource_roles_model.conf";
 static const std::string rbac_with_resource_roles_policy_path = relative_path + "/examples/rbac_with_resource_roles_policy.csv";
 static const std::string rbac_with_domains_model_path = relative_path + "/examples/rbac_with_domains_model.conf";
 static const std::string rbac_with_domains_policy_path = relative_path + "/examples/rbac_with_domains_policy.csv";
+static const std::string rbac_with_pattern_model_path = relative_path + "/examples/rbac_with_pattern_model.conf";
+static const std::string rbac_with_pattern_policy_path = relative_path + "/examples/rbac_with_pattern_policy.csv";
+static const std::string rbac_with_hierarchy_policy_path = relative_path + "/examples/rbac_with_hierarchy_policy.csv";
+static const std::string rbac_with_hierarchy_with_domains_policy_path = relative_path + "/examples/rbac_with_hierarchy_with_domains_policy.csv";
 static const std::string rbac_with_deny_model_path = relative_path + "/examples/rbac_with_deny_model.conf";
 static const std::string rbac_with_deny_policy_path = relative_path + "/examples/rbac_with_deny_policy.csv";
 

--- a/tests/enforcer_cached_test.cpp
+++ b/tests/enforcer_cached_test.cpp
@@ -18,13 +18,12 @@
 
 #include <gtest/gtest.h>
 #include <casbin/casbin.h>
+#include "config_path.h"
 
 namespace {
 
 TEST(TestEnforcerCached, TestCache) {
-    std::string model = "../../examples/basic_model.conf";
-    std::string policy = "../../examples/basic_policy.csv";
-    casbin::CachedEnforcer e(model, policy);
+    casbin::CachedEnforcer e(basic_model_path, basic_policy_path);
     ASSERT_EQ(e.Enforce({ "alice", "data1", "read" }), true);
     ASSERT_EQ(e.Enforce({ "alice", "data1", "write" }), false);
     ASSERT_EQ(e.Enforce({ "alice", "data2", "read" }), false);

--- a/tests/enforcer_synced_test.cpp
+++ b/tests/enforcer_synced_test.cpp
@@ -27,9 +27,7 @@ namespace {
 // }
 
 // TEST(TestEnforcerSynced, TestSync) {
-//     std::string model = "../../examples/basic_model.conf";
-//     std::string policy = "../../examples/basic_policy.csv";
-//     casbin::SyncedEnforcer e(model, policy);
+//     casbin::SyncedEnforcer e(basic_model_path, basic_policy_path);
 
 //     using namespace std::literals::chrono_literals;
 //     auto time1 = 200ms;
@@ -49,9 +47,7 @@ namespace {
 // }
 
 // TEST(TestEnforcerSynced, TestStopLoadPolicy) {
-//     std::string model = "../../examples/basic_model.conf";
-//     std::string policy = "../../examples/basic_policy.csv";
-//     casbin::SyncedEnforcer e(model, policy);
+//     casbin::SyncedEnforcer e(basic_model_path, basic_policy_path);
 
 //     using namespace std::literals::chrono_literals;
 //     std::chrono::duration<int64_t, std::nano> t = 5ms;

--- a/tests/enforcer_test.cpp
+++ b/tests/enforcer_test.cpp
@@ -18,13 +18,12 @@
 
 #include <gtest/gtest.h>
 #include <casbin/casbin.h>
+#include "config_path.h"
 
 namespace {
 
 TEST(TestEnforcer, TestFourParams) {
-    std::string model = "../../examples/rbac_with_domains_model.conf";
-    std::string policy = "../../examples/rbac_with_domains_policy.csv";
-    casbin::Enforcer e = casbin::Enforcer(model, policy);
+    casbin::Enforcer e(rbac_with_domains_model_path, rbac_with_domains_policy_path);
 
     ASSERT_EQ(e.Enforce({ "alice", "domain1", "data1", "read" }), true);
     ASSERT_EQ(e.Enforce({ "alice", "domain1", "data1", "write" }), true);
@@ -37,9 +36,7 @@ TEST(TestEnforcer, TestFourParams) {
 }
 
 TEST(TestEnforcer, TestThreeParams) {
-    std::string model = "../../examples/basic_model_without_spaces.conf";
-    std::string policy = "../../examples/basic_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(basic_model_without_spaces_path, basic_policy_path);
 
     ASSERT_EQ(e.Enforce({ "alice", "data1", "read" }), true);
     ASSERT_EQ(e.Enforce({ "alice", "data1", "write" }), false);
@@ -52,9 +49,7 @@ TEST(TestEnforcer, TestThreeParams) {
 }
 
 TEST(TestEnforcer, TestVectorParams) {
-    std::string model = "../../examples/basic_model_without_spaces.conf";
-    std::string policy = "../../examples/basic_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(basic_model_without_spaces_path, basic_policy_path);
 
     ASSERT_EQ(e.Enforce({ "alice", "data1", "read" }), true);
     ASSERT_EQ(e.Enforce({ "alice", "data1", "write" }), false);
@@ -67,9 +62,7 @@ TEST(TestEnforcer, TestVectorParams) {
 }
 
 TEST(TestEnforcer, TestMapParams) {
-    std::string model = "../../examples/basic_model_without_spaces.conf";
-    std::string policy = "../../examples/basic_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(basic_model_without_spaces_path, basic_policy_path);
 
     casbin::DataMap params = {{"sub", "alice"}, {"obj", "data1"}, {"act", "read"}};
     ASSERT_EQ(e.Enforce(params), true);

--- a/tests/management_api_test.cpp
+++ b/tests/management_api_test.cpp
@@ -18,13 +18,12 @@
 
 #include <gtest/gtest.h>
 #include <casbin/casbin.h>
+#include "config_path.h"
 
 namespace {
 
 TEST(TestManagementAPI, TestGetList) {
-    std::string model = "../../examples/rbac_model.conf";
-    std::string policy = "../../examples/rbac_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(rbac_model_path, rbac_policy_path);
 
     ASSERT_TRUE(casbin::ArrayEquals({ "alice", "bob", "data2_admin" }, e.GetAllSubjects()));
     ASSERT_TRUE(casbin::ArrayEquals({ "data1", "data2" }, e.GetAllObjects()));
@@ -79,9 +78,7 @@ void TestHasGroupingPolicy(casbin::Enforcer& e, const std::vector<std::string>& 
 }
 
 TEST(TestManagementAPI, TestGetPolicyAPI) {
-    std::string model = "../../examples/rbac_model.conf";
-    std::string policy = "../../examples/rbac_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(rbac_model_path, rbac_policy_path);
 
     TestGetPolicy(e, {
         {"alice", "data1", "read"},
@@ -123,10 +120,8 @@ TEST(TestManagementAPI, TestGetPolicyAPI) {
 
 
 TEST(TestManagementAPI, TestModifyPolicyAPI) {
-    std::string model = "../../examples/rbac_model.conf";
-    std::string policy = "../../examples/rbac_policy.csv";
-    std::shared_ptr<casbin::Adapter> adapter = std::make_shared<casbin::BatchFileAdapter>(policy);
-    casbin::Enforcer e(model, adapter);
+    std::shared_ptr<casbin::Adapter> adapter = std::make_shared<casbin::BatchFileAdapter>(rbac_policy_path);
+    casbin::Enforcer e(rbac_model_path, adapter);
 
     TestGetPolicy(e, {
         {"alice", "data1", "read"},
@@ -200,10 +195,8 @@ TEST(TestManagementAPI, TestModifyPolicyAPI) {
 }
 
 TEST(TestManagementAPI, TestModifyGroupingPolicyAPI) {
-    std::string model = "../../examples/rbac_model.conf";
-    std::string policy = "../../examples/rbac_policy.csv";
-    std::shared_ptr<casbin::Adapter> adapter = std::make_shared<casbin::BatchFileAdapter>(policy);
-    casbin::Enforcer e(model, adapter);
+    std::shared_ptr<casbin::Adapter> adapter = std::make_shared<casbin::BatchFileAdapter>(rbac_policy_path);
+    casbin::Enforcer e(rbac_model_path, adapter);
 
     ASSERT_TRUE(casbin::ArrayEquals({"data2_admin"}, e.GetRolesForUser("alice")));
     ASSERT_TRUE(casbin::ArrayEquals({}, e.GetRolesForUser("bob")));

--- a/tests/model_enforcer_test.cpp
+++ b/tests/model_enforcer_test.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 #include <casbin/casbin.h>
+#include "config_path.h"
 
 namespace {
 
@@ -63,9 +64,7 @@ void TestEnforce(casbin::Enforcer& e, casbin::Scope& scope, bool res) {
 }
 
 TEST(TestModelEnforcer, TestBasicModel) {
-    std::string model = "../../examples/basic_model.conf";
-    std::string policy = "../../examples/basic_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(basic_model_path, basic_policy_path);
 
     casbin::Scope scope;
 
@@ -88,9 +87,7 @@ TEST(TestModelEnforcer, TestBasicModel) {
 }
             
 TEST(TestModelEnforcer, TestBasicModelWithoutSpaces) {
-    std::string model = "../../examples/basic_model_without_spaces.conf";
-    std::string policy = "../../examples/basic_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(basic_model_without_spaces_path, basic_policy_path);
 
     casbin::Scope scope = InitializeParams("alice", "data1", "read");
     TestEnforce(e, scope, true);
@@ -111,8 +108,7 @@ TEST(TestModelEnforcer, TestBasicModelWithoutSpaces) {
 }
 
 TEST(TestModelEnforcer, TestBasicModelNoPolicy) {
-    std::string model = "../../examples/basic_model.conf";
-    casbin::Enforcer e(model);
+    casbin::Enforcer e(basic_model_path);
 
     casbin::Scope scope = InitializeParams("alice", "data1", "read");
     TestEnforce(e, scope, false);
@@ -133,9 +129,7 @@ TEST(TestModelEnforcer, TestBasicModelNoPolicy) {
 }
 
 TEST(TestModelEnforcer, TestBasicModelWithRoot) {
-    std::string model = "../../examples/basic_with_root_model.conf";
-    std::string policy = "../../examples/basic_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(basic_with_root_model_path, basic_policy_path);
 
     casbin::Scope scope = InitializeParams("alice", "data1", "read");
     TestEnforce(e, scope, true);
@@ -164,8 +158,7 @@ TEST(TestModelEnforcer, TestBasicModelWithRoot) {
 }
 
 TEST(TestModelEnforcer, TestBasicModelWithRootNoPolicy) {
-    std::string model = "../../examples/basic_with_root_model.conf";
-    casbin::Enforcer e(model);
+    casbin::Enforcer e(basic_with_root_model_path);
 
     casbin::Scope scope = InitializeParams("alice", "data1", "read");
     TestEnforce(e, scope, false);
@@ -194,9 +187,7 @@ TEST(TestModelEnforcer, TestBasicModelWithRootNoPolicy) {
 }
 
 TEST(TestModelEnforcer, TestBasicModelWithoutUsers) {
-    std::string model = "../../examples/basic_without_users_model.conf";
-    std::string policy = "../../examples/basic_without_users_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(basic_without_users_model_path, basic_without_users_policy_path);
 
     casbin::Scope scope = InitializeParamsWithoutUsers("data1", "read");
     TestEnforce(e, scope, true);
@@ -209,9 +200,7 @@ TEST(TestModelEnforcer, TestBasicModelWithoutUsers) {
 }
 
 TEST(TestModelEnforcer, TestBasicModelWithoutResources) {
-    std::string model = "../../examples/basic_without_resources_model.conf";
-    std::string policy = "../../examples/basic_without_resources_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(basic_without_resources_model_path, basic_without_resources_policy_path);
 
     casbin::Scope scope = InitializeParamsWithoutResources("alice", "read");
     TestEnforce(e, scope, true);
@@ -224,9 +213,7 @@ TEST(TestModelEnforcer, TestBasicModelWithoutResources) {
 }
 
 TEST(TestModelEnforcer, TestRBACModel) {
-    std::string model = "../../examples/rbac_model.conf";
-    std::string policy = "../../examples/rbac_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(rbac_model_path, rbac_policy_path);
 
     casbin::Scope scope = InitializeParams("alice", "data1", "read");
     TestEnforce(e, scope, true);
@@ -247,9 +234,7 @@ TEST(TestModelEnforcer, TestRBACModel) {
 }
 
 TEST(TestModelEnforcer, TestRBACModelWithResourceRoles) {
-    std::string model = "../../examples/rbac_with_resource_roles_model.conf";
-    std::string policy = "../../examples/rbac_with_resource_roles_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(rbac_with_resource_roles_model_path, rbac_with_resource_roles_policy_path);
 
     casbin::Scope scope = InitializeParams("alice", "data1", "read");
     TestEnforce(e, scope, true);
@@ -270,9 +255,7 @@ TEST(TestModelEnforcer, TestRBACModelWithResourceRoles) {
 }
 
 TEST(TestModelEnforcer, TestRBACModelWithDomains) {
-    std::string model = "../../examples/rbac_with_domains_model.conf";
-    std::string policy = "../../examples/rbac_with_domains_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(rbac_with_domains_model_path, rbac_with_domains_policy_path);
     
     casbin::Scope scope = InitializeParamsWithDomains("alice", "domain1", "data1", "read");
     TestEnforce(e, scope, true);
@@ -293,8 +276,7 @@ TEST(TestModelEnforcer, TestRBACModelWithDomains) {
 }
 
 TEST(TestModelEnforcer, TestRBACModelWithDomainsAtRuntime) {
-    std::string model = "../../examples/rbac_with_domains_model.conf";
-    casbin::Enforcer e(model);
+    casbin::Enforcer e(rbac_with_domains_model_path);
 
     std::vector<std::string> params{ "admin", "domain1", "data1", "read" };
     e.AddPolicy(params);
@@ -371,10 +353,8 @@ TEST(TestModelEnforcer, TestRBACModelWithDomainsAtRuntime) {
 }
 
 TEST(TestModelEnforcer, TestRBACModelWithDomainsAtRuntimeMockAdapter) {
-    std::string model = "../../examples/rbac_with_domains_model.conf";
-    std::string policy = "../../examples/rbac_with_domains_policy.csv";
-    std::shared_ptr<casbin::Adapter> adapter = std::make_shared<casbin::FileAdapter>(policy);
-    casbin::Enforcer e(model, adapter);
+    std::shared_ptr<casbin::Adapter> adapter = std::make_shared<casbin::FileAdapter>(rbac_with_domains_policy_path);
+    casbin::Enforcer e(rbac_with_domains_model_path, adapter);
 
     std::vector<std::string> params{ "admin", "domain3", "data1", "read" };
     e.AddPolicy(params);
@@ -400,9 +380,7 @@ TEST(TestModelEnforcer, TestRBACModelWithDomainsAtRuntimeMockAdapter) {
 }
 
 TEST(TestModelEnforcer, TestRBACModelWithDeny) {
-    std::string model = "../../examples/rbac_with_deny_model.conf";
-    std::string policy = "../../examples/rbac_with_deny_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(rbac_with_deny_model_path, rbac_with_deny_policy_path);
 
     casbin::Scope scope = InitializeParams("alice", "data1", "read");
     TestEnforce(e, scope, true);
@@ -423,18 +401,14 @@ TEST(TestModelEnforcer, TestRBACModelWithDeny) {
 }
 
 TEST(TestModelEnforcer, TestRBACModelWithOnlyDeny) {
-    std::string model = "../../examples/rbac_with_not_deny_model.conf";
-    std::string policy = "../../examples/rbac_with_deny_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(rbac_with_not_deny_model_path, rbac_with_deny_policy_path);
 
     casbin::Scope scope = InitializeParams("alice", "data2", "write");
     TestEnforce(e, scope, false);
 }
 
 TEST(TestModelEnforcer, TestRBACModelWithCustomData) {
-    std::string model = "../../examples/rbac_model.conf";
-    std::string policy = "../../examples/rbac_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(rbac_model_path, rbac_policy_path);
 
     // You can add custom data to a grouping policy, Casbin will ignore it. It is only meaningful to the caller.
     // This feature can be used to store information like whether "bob" is an end user (so no subject will inherit "bob")
@@ -484,9 +458,7 @@ TEST(TestModelEnforcer, TestRBACModelWithCustomData) {
 }
 
 TEST(TestModelEnforcer, TestRBACModelWithPattern) {
-    std::string model = "../../examples/rbac_with_pattern_model.conf";
-    std::string policy = "../../examples/rbac_with_pattern_policy.csv";
-    casbin::Enforcer e(model, policy);
+    casbin::Enforcer e(rbac_with_pattern_model_path, rbac_with_pattern_policy_path);
 
     // Here's a little confusing: the matching function here is not the custom function used in matcher.
     // It is the matching function used by "g" (and "g2", "g3" if any..)

--- a/tests/model_test.cpp
+++ b/tests/model_test.cpp
@@ -19,13 +19,13 @@
 #include <gtest/gtest.h>
 #include <casbin/casbin.h>
 #include <fstream>
+#include "config_path.h"
 
 namespace {
 
-std::string basic_example = "../../examples/basic_model.conf";
 std::shared_ptr<casbin::Config> basic_config;
 void InitTest() {
-    basic_config = casbin::Config::NewConfig(basic_example);
+    basic_config = casbin::Config::NewConfig(basic_model_path);
 }
 
 TEST(TestModel, TestNewModel) {
@@ -34,13 +34,13 @@ TEST(TestModel, TestNewModel) {
 }
 
 TEST(TestModel, TestNewModelFromFile) {
-    casbin::Model *model = casbin::Model::NewModelFromFile(basic_example);
+    casbin::Model *model = casbin::Model::NewModelFromFile(basic_model_path);
     ASSERT_NE(model, nullptr);
 }
 
 TEST(TestModel, TestNewModelFromString) {
     std::ifstream infile;
-    infile.open(basic_example);
+    infile.open(basic_model_path);
     std::string content;
     std::getline(infile, content, '\0');
     casbin::Model* model = casbin::Model::NewModelFromString(content);

--- a/tests/rbac_api_test.cpp
+++ b/tests/rbac_api_test.cpp
@@ -18,11 +18,12 @@
 
 #include <gtest/gtest.h>
 #include <casbin/casbin.h>
+#include "config_path.h"
 
 namespace {
 
 TEST(TestRBACAPI, TestRoleAPI) {
-    casbin::Enforcer e("../../examples/rbac_model.conf", "../../examples/rbac_policy.csv");
+    casbin::Enforcer e(rbac_model_path, rbac_policy_path);
 
     ASSERT_TRUE(casbin::ArrayEquals({ "data2_admin" }, e.GetRolesForUser("alice")));
     ASSERT_TRUE(casbin::ArrayEquals({ }, e.GetRolesForUser("bob")));
@@ -81,7 +82,7 @@ TEST(TestRBACAPI, TestRoleAPI) {
 }
 
 TEST(TestRBACAPI, TestEnforcer_AddRolesForUser) {
-    casbin::Enforcer e("../../examples/rbac_model.conf", "../../examples/rbac_policy.csv");
+    casbin::Enforcer e(rbac_model_path, rbac_policy_path);
 
     e.AddRolesForUser("alice", { "data1_admin", "data2_admin", "data3_admin" });
     ASSERT_TRUE(casbin::ArrayEquals({ "data1_admin", "data2_admin", "data3_admin" }, e.GetRolesForUser("alice")));
@@ -106,7 +107,7 @@ void TestGetPermissions(casbin::Enforcer& e, const std::string& name, const std:
 }
 
 TEST(TestRBACAPI, TestPermissionAPI) {
-    casbin::Enforcer e("../../examples/basic_without_resources_model.conf", "../../examples/basic_without_resources_policy.csv");
+    casbin::Enforcer e(basic_without_resources_model_path, basic_without_resources_policy_path);
 
     ASSERT_TRUE(e.Enforce({ "alice", "read" }));
     ASSERT_FALSE(e.Enforce({ "alice", "write" }));
@@ -151,7 +152,7 @@ TEST(TestRBACAPI, TestPermissionAPI) {
 }
 
 TEST(TestRBACAPI, TestImplicitRoleAPI) {
-    casbin::Enforcer e("../../examples/rbac_model.conf", "../../examples/rbac_with_hierarchy_policy.csv");
+    casbin::Enforcer e(rbac_model_path, rbac_with_hierarchy_policy_path);
 
     TestGetPermissions(e, "alice", { {"alice", "data1", "read"} });
     TestGetPermissions(e, "bob", { {"bob", "data2", "write"} });
@@ -159,7 +160,7 @@ TEST(TestRBACAPI, TestImplicitRoleAPI) {
     ASSERT_TRUE(casbin::ArrayEquals(std::vector<std::string>{ "admin", "data1_admin", "data2_admin" }, e.GetImplicitRolesForUser("alice")));
     ASSERT_TRUE(casbin::ArrayEquals(std::vector<std::string>{ }, e.GetImplicitRolesForUser("bob")));
 
-    e = casbin::Enforcer("../../examples/rbac_with_pattern_model.conf", "../../examples/rbac_with_pattern_policy.csv");
+    e = casbin::Enforcer(rbac_with_pattern_model_path, rbac_with_pattern_policy_path);
 
     dynamic_cast<casbin::DefaultRoleManager*>(e.GetRoleManager().get())->AddMatchingFunc(casbin::KeyMatch);
 
@@ -196,7 +197,7 @@ void TestGetImplicitPermissionsWithDomain(casbin::Enforcer& e, const std::string
 }
 
 TEST(TestRBACAPI, TestImplicitPermissionAPI) {
-    casbin::Enforcer e("../../examples/rbac_model.conf", "../../examples/rbac_with_hierarchy_policy.csv");
+    casbin::Enforcer e(rbac_model_path, rbac_with_hierarchy_policy_path);
 
     TestGetPermissions(e, "alice", { {"alice", "data1", "read"} });
     TestGetPermissions(e, "bob", { {"bob", "data2", "write"} });
@@ -206,12 +207,12 @@ TEST(TestRBACAPI, TestImplicitPermissionAPI) {
 }
 
 TEST(TestRBACAPI, TestImplicitPermissionAPIWithDomain) {
-    casbin::Enforcer e("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_hierarchy_with_domains_policy.csv");
+    casbin::Enforcer e(rbac_with_domains_model_path, rbac_with_hierarchy_with_domains_policy_path);
     TestGetImplicitPermissionsWithDomain(e, "alice", "domain1", { {"alice", "domain1", "data2", "read"}, { "role:reader", "domain1", "data1", "read" }, { "role:writer", "domain1", "data1", "write" } });
 }
 
 TEST(TestRBACAPI, TestImplicitUserAPI) {
-    casbin::Enforcer e("../../examples/rbac_model.conf", "../../examples/rbac_with_hierarchy_policy.csv");
+    casbin::Enforcer e(rbac_model_path, rbac_with_hierarchy_policy_path);
 
     ASSERT_TRUE(casbin::ArrayEquals({ "alice" }, e.GetImplicitUsersForPermission({ "data1", "read" })));
     ASSERT_TRUE(casbin::ArrayEquals({ "alice" }, e.GetImplicitUsersForPermission({ "data1", "write" })));

--- a/tests/rbac_api_with_domains_test.cpp
+++ b/tests/rbac_api_with_domains_test.cpp
@@ -18,11 +18,12 @@
 
 #include <gtest/gtest.h>
 #include <casbin/casbin.h>
+#include "config_path.h"
 
 namespace {
 
 TEST(TestRBACAPIWithDomains, TestGetImplicitRolesForDomainUser) {
-    casbin::Enforcer e("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_hierarchy_with_domains_policy.csv");
+    casbin::Enforcer e(rbac_with_domains_model_path, rbac_with_hierarchy_with_domains_policy_path);
 
     // This is only able to retrieve the first level of roles.
     ASSERT_TRUE(casbin::ArrayEquals({ "role:global_admin" }, e.GetRolesForUserInDomain("alice", { "domain1" })));
@@ -33,7 +34,7 @@ TEST(TestRBACAPIWithDomains, TestGetImplicitRolesForDomainUser) {
 
 // TestUserAPIWithDomains: Add by Gordon
 TEST(TestRBACAPIWithDomains, TestUserAPIWithDomains) {
-    casbin::Enforcer e("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_domains_policy.csv");
+    casbin::Enforcer e(rbac_with_domains_model_path, rbac_with_domains_policy_path);
 
     ASSERT_TRUE(casbin::ArrayEquals({ "alice" }, e.GetUsersForRole("admin", { "domain1" })));
     ASSERT_TRUE(casbin::ArrayEquals({ "alice" }, e.GetUsersForRoleInDomain("admin", { "domain1" })));
@@ -107,7 +108,7 @@ TEST(TestRBACAPIWithDomains, TestUserAPIWithDomains) {
 }
 
 TEST(TestRBACAPIWithDomains, TestRoleAPIWithDomains) {
-    casbin::Enforcer e("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_domains_policy.csv");
+    casbin::Enforcer e(rbac_with_domains_model_path, rbac_with_domains_policy_path);
     
     ASSERT_TRUE(casbin::ArrayEquals({ "admin" }, e.GetRolesForUser("alice", { "domain1" })));
     ASSERT_TRUE(casbin::ArrayEquals({ "admin" }, e.GetRolesForUserInDomain("alice", { "domain1" })));
@@ -176,7 +177,7 @@ void TestGetPermissionsInDomain(casbin::Enforcer& e, const std::string& name, co
 }
 
 TEST(TestRBACAPIWithDomains, TestPermissionAPIInDomain) {
-    casbin::Enforcer e("../../examples/rbac_with_domains_model.conf", "../../examples/rbac_with_domains_policy.csv");
+    casbin::Enforcer e(rbac_with_domains_model_path, rbac_with_domains_policy_path);
 
     TestGetPermissionsInDomain(e, "alice", "domain1", {});
     TestGetPermissionsInDomain(e, "bob", "domain1", {});


### PR DESCRIPTION
## Fixes #136 

Signed-off-by: Yash Pandey (YP) <yash.btech.cs19@iiitranchi.ac.in>

---

### Description

This code:

- Removes the relative paths used in `config_path`.
- Modifies `config_path` so as to abstract the absolute path to the `CMAKE_SOURCE_DIR` and use it to get the path to test entities.

### Screenshot

<img width="1440" alt="Screenshot 2021-08-05 at 10 40 06 PM" src="https://user-images.githubusercontent.com/62606998/128393593-d9fe87e1-2a4c-43a5-9844-fc145af84225.png">
