### PR TITLE
feat: Added python bindings for `casbin::Config`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 # Project definition.
 
 project(CasbinCPP
-    VERSION 1.36.0
+    VERSION 1.37.0
     DESCRIPTION "An authorization library that supports access control models like ACL, RBAC, ABAC in C/C++"
     HOMEPAGE_URL https://github.com/casbin/casbin-cpp
     LANGUAGES CXX C

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -18,7 +18,7 @@ set(SOURCES
     py_enforcer.cpp
     py_abac_data.cpp
     py_model.cpp
-)
+        py_config.cpp)
 
 set(HEADERS
     py_casbin.h

--- a/bindings/python/main.cpp
+++ b/bindings/python/main.cpp
@@ -38,6 +38,7 @@ PYBIND11_MODULE(pycasbin, m) {
     bindPyCachedEnforcer(m);
     bindABACData(m);
     bindPyModel(m);
+    bindPyConfig(m);
 
     m.attr("__version__") = PY_CASBIN_VERSION;
 }

--- a/bindings/python/py_casbin.h
+++ b/bindings/python/py_casbin.h
@@ -22,3 +22,4 @@ void bindPyEnforcer(py::module &m);
 void bindPyCachedEnforcer(py::module &m);
 void bindABACData(py::module &m);
 void bindPyModel(py::module &m);
+void bindPyConfig(py::module &m);

--- a/bindings/python/py_config.cpp
+++ b/bindings/python/py_config.cpp
@@ -21,7 +21,7 @@
 namespace py = pybind11;
 
 void bindPyConfig(py::module &m) {
-    py::class_<casbin::Config>(m, "Config")
+    py::class_<casbin::Config, std::shared_ptr<casbin::Config>>(m, "Config")
         .def(py::init<>())
         .def(py::init<const std::string&>())
         .def_static("NewConfig", &casbin::Config::NewConfig, R"doc(

--- a/bindings/python/py_config.cpp
+++ b/bindings/python/py_config.cpp
@@ -1,0 +1,50 @@
+/*
+* Copyright 2021 The casbin Authors. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <casbin/casbin.h>
+
+namespace py = pybind11;
+
+void bindPyConfig(py::module &m) {
+    py::class_<casbin::Config>(m, "Config")
+        .def(py::init<>())
+        .def(py::init<const std::string&>())
+        .def_static("NewConfig", &casbin::Config::NewConfig, R"doc(
+           /**
+            * NewConfig create an empty configuration representation from file.
+            *
+            * @param confName the path of the model file.
+            * @return the constructor of Config.
+            */
+        )doc")
+        .def_static("NewConfigFromText", &casbin::Config::NewConfigFromText, R"doc(
+           /**
+            * newConfigFromText create an empty configuration representation from text.
+            *
+            * @param text the model text.
+            * @return the constructor of Config.
+            */
+        )doc")
+        .def("GetBool", &casbin::Config::GetBool)
+        .def("GetInt", &casbin::Config::GetInt)
+        .def("GetFloat", &casbin::Config::GetFloat)
+        .def("GetString", &casbin::Config::GetString)
+        .def("GetStrings", &casbin::Config::GetStrings)
+        .def("Set", &casbin::Config::Set)
+        .def("Get", &casbin::Config::Get);
+}

--- a/bindings/python/py_model.cpp
+++ b/bindings/python/py_model.cpp
@@ -58,6 +58,4 @@ void bindPyModel(py::module &m) {
         .def_static("NewModel", &casbin::Model::NewModel, "NewModel creates an empty model.")
         .def_static("NewModelFromFile", &casbin::Model::NewModelFromFile, "NewModelFromFile creates a model from a .CONF file.")
         .def_static("NewModelFromString", &casbin::Model::NewModelFromString, "NewModel creates a model from a std::string which contains model text.");
-
-    m.def("LoadModelFromConfig", &PyLoadModelFromConfig);
 }

--- a/bindings/python/py_model.cpp
+++ b/bindings/python/py_model.cpp
@@ -29,6 +29,8 @@ void bindPyModel(py::module &m) {
         .def(py::init<>())
         .def(py::init<const std::string &>())
 
+        .def_readonly_static("required_sections", &casbin::Model::required_sections)
+
         .def("HasSection", &casbin::Model::HasSection)
         .def("AddDef", &casbin::Model::AddDef, "AddDef adds an assertion to the model.")
         .def("LoadModel", &casbin::Model::LoadModel, "LoadModel loads the model from model CONF file.")

--- a/bindings/python/py_model.cpp
+++ b/bindings/python/py_model.cpp
@@ -20,6 +20,10 @@
 
 #include "py_casbin.h"
 
+void PyLoadModelFromConfig(casbin::Model* model, std::shared_ptr<casbin::Config> config) {
+    model->LoadModelFromConfig(config);
+}
+
 void bindPyModel(py::module &m) {
     py::class_<casbin::Model, std::shared_ptr<casbin::Model>>(m, "Model")
         .def(py::init<>())
@@ -52,4 +56,6 @@ void bindPyModel(py::module &m) {
         .def_static("NewModel", &casbin::Model::NewModel, "NewModel creates an empty model.")
         .def_static("NewModelFromFile", &casbin::Model::NewModelFromFile, "NewModelFromFile creates a model from a .CONF file.")
         .def_static("NewModelFromString", &casbin::Model::NewModelFromString, "NewModel creates a model from a std::string which contains model text.");
+
+    m.def("LoadModelFromConfig", &PyLoadModelFromConfig);
 }

--- a/casbin/CMakeLists.txt
+++ b/casbin/CMakeLists.txt
@@ -13,65 +13,65 @@
 #  limitations under the License.
 
 set(CASBIN_SOURCE
-        abac_data.cpp
-        enforcer.cpp
-        enforcer_cached.cpp
-        enforcer_synced.cpp
-        internal_api.cpp
-        logger.cpp
-        management_api.cpp
-        pch.cpp
-        rbac_api.cpp
-        rbac_api_with_domains.cpp
-        config/config.cpp
-        duktape/duktape.cpp
-        effect/default_effector.cpp
-        ip_parser/exception/parser_exception.cpp
-        ip_parser/parser/allFF.cpp
-        ip_parser/parser/CIDRMask.cpp
-        ip_parser/parser/dtoi.cpp
-        ip_parser/parser/equal.cpp
-        ip_parser/parser/IP.cpp
-        ip_parser/parser/IPNet.cpp
-        ip_parser/parser/IPv4.cpp
-        ip_parser/parser/parseCIDR.cpp
-        ip_parser/parser/parseIP.cpp
-        ip_parser/parser/parseIPv4.cpp
-        ip_parser/parser/parseIPv6.cpp
-        ip_parser/parser/Print.cpp
-        ip_parser/parser/xtoi.cpp
-        model/assertion.cpp
-        model/function.cpp
-        model/model.cpp
-        model/scope_config.cpp
-        persist/file_adapter/batch_file_adapter.cpp
-        persist/file_adapter/file_adapter.cpp
-        persist/file_adapter/filtered_file_adapter.cpp
-        persist/adapter.cpp
-        persist/default_watcher.cpp
-        persist/default_watcher_ex.cpp
-        rbac/default_role_manager.cpp
-        util/array_equals.cpp
-        util/array_remove_duplicates.cpp
-        util/array_to_string.cpp
-        util/built_in_functions.cpp
-        util/ends_with.cpp
-        util/escape_assertion.cpp
-        util/find_all_occurences.cpp
-        util/is_instance_of.cpp
-        util/join.cpp
-        util/join_slice.cpp
-        util/remove_comments.cpp
-        util/set_subtract.cpp
-        util/split.cpp
-        util/ticker.cpp
-        util/trim.cpp
-        )
+    abac_data.cpp
+    enforcer.cpp
+    enforcer_cached.cpp
+    enforcer_synced.cpp
+    internal_api.cpp
+    logger.cpp
+    management_api.cpp
+    pch.cpp
+    rbac_api.cpp
+    rbac_api_with_domains.cpp
+    config/config.cpp
+    duktape/duktape.cpp
+    effect/default_effector.cpp
+    ip_parser/exception/parser_exception.cpp
+    ip_parser/parser/allFF.cpp
+    ip_parser/parser/CIDRMask.cpp
+    ip_parser/parser/dtoi.cpp
+    ip_parser/parser/equal.cpp
+    ip_parser/parser/IP.cpp
+    ip_parser/parser/IPNet.cpp
+    ip_parser/parser/IPv4.cpp
+    ip_parser/parser/parseCIDR.cpp
+    ip_parser/parser/parseIP.cpp
+    ip_parser/parser/parseIPv4.cpp
+    ip_parser/parser/parseIPv6.cpp
+    ip_parser/parser/Print.cpp
+    ip_parser/parser/xtoi.cpp
+    model/assertion.cpp
+    model/function.cpp
+    model/model.cpp
+    model/scope_config.cpp
+    persist/file_adapter/batch_file_adapter.cpp
+    persist/file_adapter/file_adapter.cpp
+    persist/file_adapter/filtered_file_adapter.cpp
+    persist/adapter.cpp
+    persist/default_watcher.cpp
+    persist/default_watcher_ex.cpp
+    rbac/default_role_manager.cpp
+    util/array_equals.cpp
+    util/array_remove_duplicates.cpp
+    util/array_to_string.cpp
+    util/built_in_functions.cpp
+    util/ends_with.cpp
+    util/escape_assertion.cpp
+    util/find_all_occurences.cpp
+    util/is_instance_of.cpp
+    util/join.cpp
+    util/join_slice.cpp
+    util/remove_comments.cpp
+    util/set_subtract.cpp
+    util/split.cpp
+    util/ticker.cpp
+    util/trim.cpp
+)
 
 # Setting to C++ standard to C++17
 set(CMAKE_CXX_STANDARD 17)
 
-add_library(casbin ${CASBIN_SOURCE})
+add_library(casbin STATIC ${CASBIN_SOURCE})
 target_include_directories(casbin PUBLIC ${CMAKE_SOURCE_DIR}/casbin)
 
 target_precompile_headers(casbin PUBLIC "pch.h")
@@ -89,12 +89,13 @@ elseif(UNIX)
     )
 endif()
 
-install(TARGETS casbin EXPORT CasbinTargets
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION bin
-        INCLUDES DESTINATION include
-        )
+install(
+    TARGETS casbin EXPORT CasbinTargets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include
+)
 
 install(
     DIRECTORY ${CMAKE_SOURCE_DIR}/include/casbin

--- a/casbin/config/config.cpp
+++ b/casbin/config/config.cpp
@@ -114,6 +114,10 @@ std::shared_ptr<Config> Config::NewConfigFromText(const std::string& text) {
     return c;
 }
 
+Config::Config(const std::string& conf_name) {
+    this->Parse(conf_name);
+}
+
 bool Config::GetBool(std::string_view key) {
     return Get(key).compare("true")==0;
 }

--- a/casbin/config/config.cpp
+++ b/casbin/config/config.cpp
@@ -114,6 +114,9 @@ std::shared_ptr<Config> Config::NewConfigFromText(const std::string& text) {
     return c;
 }
 
+Config::Config() {
+}
+
 Config::Config(const std::string& conf_name) {
     this->Parse(conf_name);
 }

--- a/casbin/config/config.h
+++ b/casbin/config/config.h
@@ -64,6 +64,8 @@ class Config : public ConfigInterface {
 
         bool GetBool(std::string_view key);
 
+        Config(const std::string& conf_name);
+
         int GetInt(std::string_view key);
 
         float GetFloat(std::string_view key);

--- a/casbin/config/config.h
+++ b/casbin/config/config.h
@@ -64,6 +64,8 @@ class Config : public ConfigInterface {
 
         bool GetBool(std::string_view key);
 
+        Config();
+
         Config(const std::string& conf_name);
 
         int GetInt(std::string_view key);

--- a/casbin/model/model.cpp
+++ b/casbin/model/model.cpp
@@ -39,7 +39,7 @@ std::unordered_map<std::string, std::string> Model::section_name_map = {
 
 std::vector<std::string> Model::required_sections{"r","p","e","m"};
 
-void Model::LoadModelFromConfig(std::shared_ptr<ConfigInterface> cfg) {
+void Model::LoadModelFromConfig(std::shared_ptr<Config>& cfg) {
     for (auto [section_name, _] : section_name_map)
         LoadSection(this ,cfg, section_name);
 

--- a/casbin/model/model.h
+++ b/casbin/model/model.h
@@ -24,6 +24,7 @@
 #include "assertion.h"
 #include "function.h"
 #include "scope_config.h"
+#include "../config/config.h"
 
 namespace casbin {
 
@@ -68,7 +69,7 @@ class Model {
         // LoadModelFromText loads the model from the text.
         void LoadModelFromText(const std::string& text);
 
-        void LoadModelFromConfig(std::shared_ptr<ConfigInterface> cfg);
+        void LoadModelFromConfig(std::shared_ptr<Config>& cfg);
 
         // PrintModel prints the model to the log.
         void PrintModel();

--- a/include/casbin/casbin_helpers.h
+++ b/include/casbin/casbin_helpers.h
@@ -54,7 +54,7 @@ namespace casbin {
         std::unordered_map<std::string, std::unordered_map<std::string, std::string>> data;
 
         /**
-         * addConfig adds a new section->key:value to the configuration.
+            * addConfig adds a new section->key:value to the configuration.
          */
         bool AddConfig(std::string section, const std::string& option, const std::string& value);
 
@@ -81,6 +81,10 @@ namespace casbin {
         static std::shared_ptr<Config> NewConfigFromText(const std::string& text);
 
         bool GetBool(std::string_view key);
+
+        Config();
+
+        Config(const std::string& conf_name);
 
         int GetInt(std::string_view key);
 
@@ -206,7 +210,7 @@ namespace casbin {
             // LoadModelFromText loads the model from the text.
             void LoadModelFromText(const std::string& text);
 
-            void LoadModelFromConfig(std::shared_ptr<ConfigInterface> cfg);
+            void LoadModelFromConfig(std::shared_ptr<Config>& cfg);
 
             // PrintModel prints the model to the log.
             void PrintModel();

--- a/tests/model_test.cpp
+++ b/tests/model_test.cpp
@@ -50,7 +50,7 @@ TEST(TestModel, TestNewModelFromString) {
 
 TEST(TestModel, TestLoadModelFromConfig) {
     InitTest();
-     std::shared_ptr<casbin::Model> model = casbin::Model::NewModel();
+    std::shared_ptr<casbin::Model> model = casbin::Model::NewModel();
     model->LoadModelFromConfig(basic_config);
 
     model = casbin::Model::NewModel();

--- a/tests/python/config_path.py
+++ b/tests/python/config_path.py
@@ -28,3 +28,4 @@ rbac_with_deny_policy_path = relative_path + 'examples/rbac_with_deny_policy.csv
 priority_model_path = relative_path + 'examples/priority_model.conf'
 priority_policy_path = relative_path + 'examples/priority_policy.csv'
 basic_model_without_spaces_path = relative_path + 'examples/basic_model_without_spaces.conf'
+testini_path = relative_path + 'casbin/config/testdata/testini.ini'

--- a/tests/python/pycasbin_test_suite.py
+++ b/tests/python/pycasbin_test_suite.py
@@ -18,6 +18,7 @@ import os
 import pycasbin
 import test_enforcer
 import test_model
+import test_config
 
 def suite():
 
@@ -27,6 +28,7 @@ def suite():
 
     suite.addTest(loader.loadTestsFromModule(test_enforcer))
     suite.addTest(loader.loadTestsFromModule(test_model))
+    suite.addTest(loader.loadTestsFromModule(test_config))
 
     return suite
 

--- a/tests/python/test_config.py
+++ b/tests/python/test_config.py
@@ -1,0 +1,39 @@
+#  Copyright 2021 The casbin Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pycasbin as casbin
+from config_path import *
+import unittest
+
+class TestConfig(unittest.TestCase):
+
+    def setUp(self):
+        self.config = None
+
+    def tearDown(self):
+        self.config = None
+
+    def test_Debug(self):
+        self.config = casbin.Config.NewConfig(testini_path)
+        self.assertTrue(self.config.GetBool('debug'))
+
+    def test_URL(self):
+        self.config = casbin.Config.NewConfig(testini_path)
+        self.assertEqual(self.config.GetString('url'), 'act.wiki')
+
+    def test_Redis(self):
+        self.config = casbin.Config.NewConfig(testini_path)
+        values = self.config.GetStrings('redis::redis.key')
+        self.assertEqual('push1', values[0])
+        self.assertEqual('push2', values[1])

--- a/tests/python/test_model.py
+++ b/tests/python/test_model.py
@@ -18,18 +18,30 @@ import unittest
 
 class TestModel(unittest.TestCase):
 
-    # def setUp(self):
-        # self.basic_config = casbin.Config.NewConfig(basic_model_path)
+    def setUp(self):
+        self.model = None
+        self.config = None
+
+    def cleanUp(self):
+        self.model = None
+        self.config = None
+
+    def tearDown(self):
+        self.model = None
+        self.config = None
 
     def test_NewModel(self):
-        model = casbin.Model.NewModel()
-        self.assertIsNotNone(model)
+        self.cleanUp()
+        self.model = casbin.Model.NewModel()
+        self.assertIsNotNone(self.model)
 
     def test_NewModelFromFile(self):
-        model = casbin.Model.NewModelFromFile(basic_model_path)
-        self.assertIsNotNone(model)
+        self.cleanUp()
+        self.model = casbin.Model.NewModelFromFile(basic_model_path)
+        self.assertIsNotNone(self.model)
 
     def test_NewModelFromString(self):
+        self.cleanUp()
         model_string = """[request_definition]
 r = sub, obj, act
 
@@ -41,19 +53,40 @@ e = some(where (p.eft == allow))
 
 [matchers]
 m = r.sub == p.sub && r.obj == p.obj && r.act == p.act"""
-        model = casbin.Model.NewModelFromString(model_string)
-        self.assertIsNotNone(model)
+        self.model = casbin.Model.NewModelFromString(model_string)
+        self.assertIsNotNone(self.model)
 
     def test_LoadModelFromConfig(self):
-        basic_config = casbin.Config.NewConfig(basic_model_path)
-        model = casbin.Model.NewModel()
-        model.LoadModelFromConfig(basic_config)
-        # model = casbin.Model.NewModel()
-        # config = casbin.Config.NewConfigFromText("")
-        # model.LoadModelFromConfig(config)
+        self.cleanUp()
+        self.config = casbin.Config.NewConfig(basic_model_path)
+        self.model = casbin.Model.NewModel()
+        self.model.LoadModelFromConfig(self.config)
+        self.model = casbin.Model.NewModel()
+        self.config = casbin.Config.NewConfigFromText('')
+        # self.assertRaises('', model.LoadModelFromConfig(basic_config))
 
     def test_HasSection(self):
-        # config = casbin.Config.NewConfig(basic_model_path)
-        # model = casbin.Model.NewModel()
-        # casbin.LoadModelFromConfig(model, basic_config)
+        self.cleanUp()
+        self.config = casbin.Config.NewConfig(basic_model_path)
+        self.model = casbin.Model.NewModel()
+        self.model.LoadModelFromConfig(self.config)
+        for required_section in casbin.Model.required_sections:
+            self.assertTrue(self.model.HasSection(required_section))
 
+        self.cleanUp()
+        self.model = casbin.Model.NewModel()
+        self.config = casbin.Config.NewConfigFromText('')
+        # self.assertRaises('', model.LoadModelFromConfig(config))
+
+        for required_section in casbin.Model.required_sections:
+            self.assertFalse(self.model.HasSection(required_section))
+
+    def test_ModelAddDef(self):
+        self.cleanUp()
+        self.model = casbin.Model.NewModel()
+        s = 'r'
+        v = 'sub, obj, act'
+
+        self.assertTrue(self.model.AddDef(s, s, v))
+
+        self.assertFalse(self.model.AddDef(s, s, ''))

--- a/tests/python/test_model.py
+++ b/tests/python/test_model.py
@@ -45,9 +45,9 @@ m = r.sub == p.sub && r.obj == p.obj && r.act == p.act"""
         self.assertIsNotNone(model)
 
     def test_LoadModelFromConfig(self):
-        # config = casbin.Config(basic_model_path)
-        # model = casbin.Model.NewModel()
-        # casbin.LoadModelFromConfig(model, basic_config)
+        basic_config = casbin.Config.NewConfig(basic_model_path)
+        model = casbin.Model.NewModel()
+        model.LoadModelFromConfig(basic_config)
         # model = casbin.Model.NewModel()
         # config = casbin.Config.NewConfigFromText("")
         # model.LoadModelFromConfig(config)

--- a/tests/python/test_model.py
+++ b/tests/python/test_model.py
@@ -17,6 +17,10 @@ from config_path import *
 import unittest
 
 class TestModel(unittest.TestCase):
+
+    # def setUp(self):
+        # self.basic_config = casbin.Config.NewConfig(basic_model_path)
+
     def test_NewModel(self):
         model = casbin.Model.NewModel()
         self.assertIsNotNone(model)
@@ -25,8 +29,31 @@ class TestModel(unittest.TestCase):
         model = casbin.Model.NewModelFromFile(basic_model_path)
         self.assertIsNotNone(model)
 
-    # def test_NewModelFromString(self):
-    #     with open(basic_model_path, 'r') as model_file:
-    #         model_string = model_file.read().replace('\n', '')
-    #     model = casbin.Model.NewModelFromString(model_string)
-    #     self.assertIsNotNone(model)
+    def test_NewModelFromString(self):
+        model_string = """[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = r.sub == p.sub && r.obj == p.obj && r.act == p.act"""
+        model = casbin.Model.NewModelFromString(model_string)
+        self.assertIsNotNone(model)
+
+    def test_LoadModelFromConfig(self):
+        # config = casbin.Config(basic_model_path)
+        # model = casbin.Model.NewModel()
+        # casbin.LoadModelFromConfig(model, basic_config)
+        # model = casbin.Model.NewModel()
+        # config = casbin.Config.NewConfigFromText("")
+        # model.LoadModelFromConfig(config)
+
+    def test_HasSection(self):
+        # config = casbin.Config.NewConfig(basic_model_path)
+        # model = casbin.Model.NewModel()
+        # casbin.LoadModelFromConfig(model, basic_config)
+


### PR DESCRIPTION
## Fixes #84 partially

Signed-off-by: Yash Pandey (YP) <yash.btech.cs19@iiitranchi.ac.in>

---

### Description

This code:

- Implements python bindings for `casbin::Config`
- Modified the API to facilitate the bindings
- Added python tests for `pycasbin.Config` and `pycasbin.Model`

The workflow enabled by the API exposed to the python side can be abstracted as follows:

```python
import pycasbin as casbin

# For casbin.Config
config = casbin.Config.NewConfig('path/to/config/file.ini')
config = casbin.Config.NewConfigFromText('<contents of the config>')
ok = config.GetBool('<key>')
num_value = config.GetInt('<key')

# ... and so on

# For casbin.Model
model = casbin.Model.NewModel() # empty model
model = casbin.Model.NewModelFromFile('path/to/model.conf')
model = casbin.Model.NewModelFromString('<contents of the model>')

# Demonstrating casbin.Model.LoadModelFromConfig
config = casbin.Config.NewConfig('path/to/model.conf')
model = casbin.Model.NewModel()
model.LoadModelFromConfig(config)
```

### Screenshots

<img width="538" alt="Screenshot 2021-08-10 at 9 59 06 PM" src="https://user-images.githubusercontent.com/62606998/128897276-23d98d24-65be-4dd6-9b08-44932904604f.png">
