### PR TITLE
chore: Updated project config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,6 @@ jobs:
         run: |
           cd build
           ctest -j10 -C Debug -T test --output-on-failure -T test --output-on-failure
-      - name: Cleanup
-        id: clean-up
-        run: |
-          rm -r build
 
   macos:
     name: "macOS Catalina 10.15 (AppleClang 12.0)"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 # Project definition.
 
 project(CasbinCPP
-    VERSION 1.38.2
+    VERSION 1.38.0
     DESCRIPTION "An authorization library that supports access control models like ACL, RBAC, ABAC in C/C++"
     HOMEPAGE_URL https://github.com/casbin/casbin-cpp
     LANGUAGES CXX C
@@ -54,6 +54,7 @@ option(CASBIN_BUILD_TEST "State whether to build test" ON)
 option(CASBIN_BUILD_BENCHMARK "State whether to build benchmarks" ON)
 option(CASBIN_BUILD_BINDINGS "State whether to build language bindings" ON)
 option(CASBIN_BUILD_PYTHON_BINDINGS "State whether to build python bindings" ON)
+
 
 # Do not output install messages.
 if(NOT DEFINED CMAKE_INSTALL_MESSAGE)
@@ -78,7 +79,7 @@ endif()
 set(CMAKE_CXX_STANDARD 17)
 
 ###############################################################################
-# Find or install external dependencies
+# Install external dependencies
 # Some required targets may be created by third-party CMake configs, which 
 # don't generally produce global targets. To guarantee all imported targets are 
 # global, this module is included at the project root level.
@@ -86,16 +87,3 @@ set(CMAKE_CXX_STANDARD 17)
 include(FindExtPackages)
 
 add_subdirectory(casbin)
-
-export(TARGETS
-    casbin
-    NAMESPACE casbin::
-    FILE "${CMAKE_CURRENT_BINARY_DIR}/CasbinConfig.cmake"
-)
-
-if(CASBIN_BUILD_PYTHON_BINDINGS)
-    export(TARGETS pycasbin
-        NAMESPACE casbin::
-        FILE "${CMAKE_CURRENT_BINARY_DIR}/PyCasbinConfig.cmake"
-    )
-endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,8 @@ endif()
 ###############################################################################
 # Project definition.
 
-project(CasbinCPP
+project(
+    casbin
     VERSION 1.38.0
     DESCRIPTION "An authorization library that supports access control models like ACL, RBAC, ABAC in C/C++"
     HOMEPAGE_URL https://github.com/casbin/casbin-cpp

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+find_package(Python REQUIRED COMPONENTS Interpreter Development)
+
 set(SOURCES
     main.cpp
     py_cached_enforcer.cpp
@@ -26,7 +28,7 @@ set(HEADERS
     py_casbin.h
 )
 
-add_library(pycasbin MODULE ${SOURCES} ${HEADERS})
+Python_add_library(pycasbin MODULE ${SOURCES} ${HEADERS})
 
 target_include_directories(pycasbin PUBLIC ${CMAKE_SOURCE_DIR}/include)
 
@@ -35,6 +37,7 @@ set_target_properties(pycasbin PROPERTIES
     CXX_STANDARD 17
 )
 
+# For in-source versioning macro
 add_definitions(-DPY_CASBIN_VERSION=${PY_CASBIN_VERSION})
 
 if(WIN32)
@@ -70,10 +73,12 @@ target_link_libraries(pycasbin
 )
 
 if(WIN32)
-    set(Python_VARIANT_PATH "lib${LIB_SUFFIX}/site-packages")
+    set(Python_VARIANT_PATH lib${LIB_SUFFIX}/site-packages)
 else()
-    set(Python_VARIANT_PATH "lib${LIB_SUFFIX}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+    set(Python_VARIANT_PATH lib${LIB_SUFFIX}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages)
 endif()
+
+message("${Python_VARIANT_PATH}")
 
 # For testing
 install(

--- a/casbin/CMakeLists.txt
+++ b/casbin/CMakeLists.txt
@@ -72,12 +72,13 @@ set(CASBIN_SOURCE
 set(CMAKE_CXX_STANDARD 17)
 
 add_library(casbin STATIC ${CASBIN_SOURCE})
-target_include_directories(casbin PUBLIC ${CMAKE_SOURCE_DIR}/casbin)
 
-target_precompile_headers(casbin PUBLIC "pch.h")
+target_precompile_headers(casbin PUBLIC pch.h)
+target_include_directories(casbin PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 set_target_properties(casbin PROPERTIES 
     PREFIX ""
+    VERSION ${CMAKE_PROJECT_VERSION}
 )
 
 if(WIN32 OR MSVC)
@@ -88,16 +89,3 @@ elseif(UNIX)
         POSITION_INDEPENDENT_CODE ON
     )
 endif()
-
-install(
-    TARGETS casbin EXPORT CasbinTargets
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-    RUNTIME DESTINATION bin
-    INCLUDES DESTINATION include
-)
-
-install(
-    DIRECTORY ${CMAKE_SOURCE_DIR}/include/casbin
-    DESTINATION include
-)

--- a/cmake/modules/FindExtPackages.cmake
+++ b/cmake/modules/FindExtPackages.cmake
@@ -38,6 +38,7 @@ endif()
 
 if(CASBIN_BUILD_BINDINGS)
     if(CASBIN_BUILD_PYTHON_BINDINGS)
+        find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
         # pybind11
         # https://github.com/pybind/pybind11
         find_package(pybind11 2.7.0 REQUIRED)

--- a/cmake/modules/Findbenchmark.cmake
+++ b/cmake/modules/Findbenchmark.cmake
@@ -21,3 +21,10 @@ FetchContent_Declare(
 
 set(BENCHMARK_ENABLE_TESTING OFF)
 FetchContent_MakeAvailable(benchmark)
+
+FetchContent_GetProperties(benchmark)
+
+if(NOT benchmark_POPULATED)
+  FetchContent_Populate(benchmark)
+  add_subdirectory(${benchmark_SOURCE_DIR} ${benchmark_BINARY_DIR})
+endif()

--- a/cmake/modules/Findgoogletest.cmake
+++ b/cmake/modules/Findgoogletest.cmake
@@ -13,10 +13,21 @@
 #  limitations under the License.
 
 include(FetchContent)
+
 FetchContent_Declare(
   googletest
-  URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG release-1.11.0
 )
+
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
 FetchContent_MakeAvailable(googletest)
+FetchContent_GetProperties(googletest)
+
+# Populating manually, if not done automatically
+if(NOT googletest_POPULATED)
+  FetchContent_Populate(googletest)
+  add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
+endif()

--- a/cmake/modules/Findpybind11.cmake
+++ b/cmake/modules/Findpybind11.cmake
@@ -16,7 +16,16 @@ include(FetchContent)
 
 FetchContent_Declare(
   pybind11
-  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.7.0.zip
+  GIT_REPOSITORY https://github.com/pybind/pybind11.git
+  GIT_TAG v2.7.1
 )
 
 FetchContent_MakeAvailable(pybind11)
+
+FetchContent_GetProperties(pybind11)
+
+# Populating manually, if not done automatically
+if(NOT pybind11_POPULATED)
+  FetchContent_Populate(pybind11)
+  add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
+endif()


### PR DESCRIPTION
Signed-off-by: Yash Pandey (YP) <yash.btech.cs19@iiitranchi.ac.in>

This code:

- Changes the `CMAKE_PROJECT_NAME` to casbin and `CMAKE_PROJECT_VERSION` to 1.37.1
- Removes unnecessary installations
- Properly installs `pycasbin.so`/`pycasbin.pyd` to its desired path
- Configures include paths to be inline with the [intended client-side configuration](https://github.com/EmperorYP7/casbin-CMake-setup)
