### PR TITLE
fix: Use of CachedEnforcer throws error from clang

### DIFF
--- a/casbin/enforcer_cached.h
+++ b/casbin/enforcer_cached.h
@@ -84,6 +84,8 @@ public:
          */
     CachedEnforcer(const std::string& model_path, const std::string& policy_file, bool enable_log);
 
+    virtual ~CachedEnforcer() = default;
+
     bool Enforce(Scope scope);
 
     // Enforce with a vector param,decides whether a "subject" can access a

--- a/include/casbin/casbin_types.h
+++ b/include/casbin/casbin_types.h
@@ -19,6 +19,7 @@
 #ifndef CASBIN_CPP_CASBIN_TYPES_H
 #define CASBIN_CPP_CASBIN_TYPES_H
 
+#include <string>
 #include <variant>
 #include <vector>
 #include <initializer_list>


### PR DESCRIPTION
## Fixes #152 

Signed-off-by: William Michaels <bill@polarity.io>

### Description

 - add `<string>` to casbin_types.h for visibility of `std::hash<std::string>` of CachedEnforcer's `std::unordered_map`
 - add default virtual destructor

```
	/include/c++/4.2.1
	Apple clang version 12.0.5 (clang-1205.0.22.11)
	Target: x86_64-apple-darwin20.2.0
```



