### PR TITLE
fix: fix casbin::Enforcer::AddPolicies() (#117)

### DIFF
--- a/casbin/enforcer.cpp
+++ b/casbin/enforcer.cpp
@@ -25,6 +25,7 @@
 #include "./enforcer.h"
 #include "./persist/watcher_ex.h"
 #include "./persist/file_adapter/file_adapter.h"
+#include "./persist/file_adapter/batch_file_adapter.h"
 #include "./rbac/default_role_manager.h"
 #include "./effect/default_effector.h"
 #include "./exception/casbin_adapter_exception.h"
@@ -179,7 +180,7 @@ Enforcer ::Enforcer() {
  * @param policyFile the path of the policy file.
  */
 Enforcer ::Enforcer(const std::string& model_path, const std::string& policy_file)
-    : Enforcer(model_path, std::make_shared<FileAdapter>(policy_file)) {
+    : Enforcer(model_path, std::make_shared<BatchFileAdapter>(policy_file)) {
 }
 
 /**
@@ -233,14 +234,14 @@ Enforcer ::Enforcer(const std::string& model_path): Enforcer(model_path, "") {
  * @param enableLog whether to enable Casbin's log.
  */
 Enforcer::Enforcer(const std::string& model_path, const std::string& policy_file, bool enable_log)
-    : Enforcer(model_path, std::make_shared<FileAdapter>(policy_file)) {
+    : Enforcer(model_path, std::make_shared<BatchFileAdapter>(policy_file)) {
     this->EnableLog(enable_log);
 }
 
 
 // InitWithFile initializes an enforcer with a model file and a policy file.
 void Enforcer::InitWithFile(const std::string& model_path, const std::string& policy_path) {
-    std::shared_ptr<Adapter> a = std::make_shared<FileAdapter>(policy_path);
+    std::shared_ptr<Adapter> a = std::make_shared<BatchFileAdapter>(policy_path);
     this->InitWithAdapter(model_path, a);
 }
 

--- a/tests/rbac_api_test.cpp
+++ b/tests/rbac_api_test.cpp
@@ -222,8 +222,10 @@ TEST(TestRBACAPI, TestImplicitUserAPI) {
     e.ClearPolicy();
     e.AddPolicy({ "admin", "data1", "read" });
     e.AddPolicy({ "bob", "data1", "read" });
+    e.AddPolicies({{ "tom", "data1", "read" }, {"john", "data1", "read" }});
     e.AddGroupingPolicy({ "alice", "admin" });
-    ASSERT_TRUE(casbin::ArrayEquals({ "alice", "bob" }, e.GetImplicitUsersForPermission({ "data1", "read" })));
+    
+    ASSERT_TRUE(casbin::ArrayEquals({ "alice", "bob", "tom", "john"}, e.GetImplicitUsersForPermission({ "data1", "read" })));
 }
 
 } // namespace


### PR DESCRIPTION
- change FileAdaptor to BatchFileAdaptor when construct file adopter
- https://github.com/casbin/casbin-cpp/issues/117

Signed-off-by: stonex <1479765922@qq.com>

<!--
    We follow semantic pull requests. Make sure you sign-off and format every commit message
    as well as the PR title as specified in 
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

    Eg. feat: New feature name,
    fix: Some error, etc.
-->

## Fixes #117
+ Error while using casbin::Enforcer::AddPolicies()
### Description
+ I have something wrong when I run benchmark, so I don't test it in benchmark. But I test it in tests/rbac_api_test.cpp.
+ I think it's caused when you use a normal fileAdoptor, but you  want to use batch apis (e.g. `casbin::Enforcer::AddPolicies()`). Then this function result in a segmentation fault. 
+ I change the construct fucntion of `casbin::Enforcer`  use `BatchFileAdapter` rather than `FileAdapter`.


