### PR TITLE
fix: fix memory leakage in DefaultRoleManager::Clear() and in Default…

### DIFF
--- a/casbin/rbac/default_role_manager.h
+++ b/casbin/rbac/default_role_manager.h
@@ -31,16 +31,16 @@ typedef bool (*MatchingFunc)(const std::string&, const std::string&);
 class Role {
     
     private:
-        std::vector<Role*> roles;
+        std::vector<std::shared_ptr<Role>> roles;
 
     public:
         std::string name;
 
-        static Role* NewRole(std::string name);
+        static std::shared_ptr<Role> NewRole(std::string name);
         
-        void AddRole(Role* role);
+        void AddRole(std::shared_ptr<Role> role);
 
-        void DeleteRole(Role* role);
+        void DeleteRole(std::shared_ptr<Role> role);
 
         bool HasRole(std::string name, int hierarchy_level);
 
@@ -53,14 +53,14 @@ class Role {
 
 class DefaultRoleManager : public RoleManager {
     private:
-        std::unordered_map<std::string, Role*> all_roles;
+        std::unordered_map<std::string, std::shared_ptr<Role>> all_roles;
         bool has_pattern;
         int max_hierarchy_level;
         MatchingFunc matching_func;
 
         bool HasRole(std::string name);
 
-        Role* CreateRole(std::string name);
+        std::shared_ptr<Role> CreateRole(std::string name);
 
     public:
 


### PR DESCRIPTION

Signed-off-by: stonex <1479765922@qq.com>

<!--
    We follow semantic pull requests. Make sure you sign-off and format every commit message
    as well as the PR title as specified in 
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

    Eg. feat: New feature name,
    fix: Some error, etc.
-->

## Fixes #119 

### Description
+ There are two main memory leak.
+ [DefaultRoleManager::Clear()](https://github.com/casbin/casbin-cpp/blob/4ba0cda32dddea5835a4406599460f58980071d3/casbin/rbac/default_role_manager.cpp#L168) and [DefaultRoleManager::CreateRole()](https://github.com/casbin/casbin-cpp/blob/4ba0cda32dddea5835a4406599460f58980071d3/casbin/rbac/default_role_manager.cpp#L133).
+ Change native pointer to smart pointer. When remove the pointer from vector, the memory will be free.

### Screenshots/Testimonials
+ Use `valgrind --tool=memcheck` test the benchmark and no memory leakage.

![image](https://user-images.githubusercontent.com/43725202/139583019-212e818e-ffcb-4697-834c-03ebc04da633.png)

![image](https://user-images.githubusercontent.com/43725202/139583007-c53ff01a-7640-4de0-b84d-42372bb88f69.png)



