### PR TITLE
fix: expedite benchmark tests

### DIFF
--- a/casbin/rbac/default_role_manager.h
+++ b/casbin/rbac/default_role_manager.h
@@ -1,3 +1,4 @@
+
 /*
 * Copyright 2020 The casbin Authors. All Rights Reserved.
 *
@@ -31,16 +32,16 @@ typedef bool (*MatchingFunc)(const std::string&, const std::string&);
 class Role {
     
     private:
-        std::vector<Role*> roles;
+        std::vector<std::shared_ptr<Role>> roles;
 
     public:
         std::string name;
 
-        static Role* NewRole(std::string name);
+        static std::shared_ptr<Role> NewRole(std::string name);
         
-        void AddRole(Role* role);
+        void AddRole(std::shared_ptr<Role> role);
 
-        void DeleteRole(Role* role);
+        void DeleteRole(std::shared_ptr<Role> role);
 
         bool HasRole(std::string name, int hierarchy_level);
 
@@ -53,14 +54,14 @@ class Role {
 
 class DefaultRoleManager : public RoleManager {
     private:
-        std::unordered_map<std::string, Role*> all_roles;
+        std::unordered_map<std::string, std::shared_ptr<Role>> all_roles;
         bool has_pattern;
         int max_hierarchy_level;
         MatchingFunc matching_func;
 
         bool HasRole(std::string name);
 
-        Role* CreateRole(std::string name);
+        std::shared_ptr<Role> CreateRole(std::string name);
 
     public:
 

--- a/tests/benchmarks/enforcer_cached_b.cpp
+++ b/tests/benchmarks/enforcer_cached_b.cpp
@@ -47,7 +47,7 @@ BENCHMARK(BenchmarkCachedRBACModel);
 
 // BENCHMARK(BenchmarkCachedRaw);
 
-static void BenchmarkCachedRBACModelLoop(benchmark::State& state) {
+static void BenchmarkCachedRBACModelSmall(benchmark::State& state) {
     casbin::CachedEnforcer e(rbac_model_path, "", false);
     // 100 roles, 10 resources.
     for (int i = 0; i < 100; ++i)
@@ -60,7 +60,53 @@ static void BenchmarkCachedRBACModelLoop(benchmark::State& state) {
         e.Enforce(params);
 }
 
-BENCHMARK(BenchmarkCachedRBACModelLoop);
+BENCHMARK(BenchmarkCachedRBACModelSmall);
+
+static void BenchmarkCachedRBACModelMedium(benchmark::State& state) {
+    casbin::CachedEnforcer e(rbac_model_path, "", false);
+    std::vector<std::vector<std::string>> p_policies(1000);
+    // 1000 roles, 100 resources.
+    for (int i = 0; i < 1000; ++i)
+        p_policies[i] = { "group" + std::to_string(i), "data" + std::to_string(i / 10), "read" };
+
+    e.AddPolicies(p_policies);
+
+    // 10000 users.
+    std::vector<std::vector<std::string>> g_policies(10000);
+    for (int i = 0; i < 10000; ++i)
+        g_policies[i] = { "user" + std::to_string(i), "group" + std::to_string(i/10) };
+
+    e.AddGroupingPolicies(g_policies);
+    casbin::DataList params = {"user5001", "data150", "read"};
+    for (auto _ : state)
+        e.Enforce(params);
+}
+
+// BENCHMARK(BenchmarkCachedRBACModelMedium);
+
+static void BenchmarkCachedRBACModelLarge(benchmark::State& state) {
+    casbin::CachedEnforcer e(rbac_model_path, "", false);
+
+    // 10000 roles, 1000 resources.
+    std::vector<std::vector<std::string>> p_policies(10000);
+    for (int i = 0; i < 10000; ++i)
+        p_policies[i] = {"group", std::to_string(i), "data", std::to_string(i / 10), "read"};
+    e.AddPolicies(p_policies);
+
+    // 100000 users.
+    std::vector<std::vector<std::string>> g_policies(100000);
+    for (int i = 0; i < 100000; ++i) {
+        g_policies[i] = {"user" + std::to_string(i), "group", std::to_string(i / 10)};
+    }
+    e.AddGroupingPolicies(g_policies);
+    casbin::DataList params = {"user50001", "data1500", "read"};
+    for (auto _ : state)
+    {
+        e.Enforce(params);
+    }
+}
+
+// BENCHMARK(BenchmarkCachedRBACModelLarge);
 
 static void BenchmarkCachedRBACModelWithResourceRoles(benchmark::State& state) {
     casbin::CachedEnforcer e(rbac_with_resource_roles_model_path, rbac_with_resource_roles_policy_path, false);

--- a/tests/benchmarks/enforcer_cached_b.cpp
+++ b/tests/benchmarks/enforcer_cached_b.cpp
@@ -47,7 +47,7 @@ BENCHMARK(BenchmarkCachedRBACModel);
 
 // BENCHMARK(BenchmarkCachedRaw);
 
-static void BenchmarkCachedRBACModelSmall(benchmark::State& state) {
+static void BenchmarkCachedRBACModelLoop(benchmark::State& state) {
     casbin::CachedEnforcer e(rbac_model_path, "", false);
     // 100 roles, 10 resources.
     for (int i = 0; i < 100; ++i)
@@ -60,53 +60,7 @@ static void BenchmarkCachedRBACModelSmall(benchmark::State& state) {
         e.Enforce(params);
 }
 
-BENCHMARK(BenchmarkCachedRBACModelSmall);
-
-static void BenchmarkCachedRBACModelMedium(benchmark::State& state) {
-    casbin::CachedEnforcer e(rbac_model_path, "", false);
-    std::vector<std::vector<std::string>> p_policies(1000);
-    // 1000 roles, 100 resources.
-    for (int i = 0; i < 1000; ++i)
-        p_policies[i] = { "group" + std::to_string(i), "data" + std::to_string(i / 10), "read" };
-
-    e.AddPolicies(p_policies);
-
-    // 10000 users.
-    std::vector<std::vector<std::string>> g_policies(10000);
-    for (int i = 0; i < 10000; ++i)
-        g_policies[i] = { "user" + std::to_string(i), "group" + std::to_string(i/10) };
-
-    e.AddGroupingPolicies(g_policies);
-    casbin::DataList params = {"user5001", "data150", "read"};
-    for (auto _ : state)
-        e.Enforce(params);
-}
-
-// BENCHMARK(BenchmarkCachedRBACModelMedium);
-
-static void BenchmarkCachedRBACModelLarge(benchmark::State& state) {
-    casbin::CachedEnforcer e(rbac_model_path, "", false);
-
-    // 10000 roles, 1000 resources.
-    std::vector<std::vector<std::string>> p_policies(10000);
-    for (int i = 0; i < 10000; ++i)
-        p_policies[i] = {"group", std::to_string(i), "data", std::to_string(i / 10), "read"};
-    e.AddPolicies(p_policies);
-
-    // 100000 users.
-    std::vector<std::vector<std::string>> g_policies(100000);
-    for (int i = 0; i < 100000; ++i) {
-        g_policies[i] = {"user" + std::to_string(i), "group", std::to_string(i / 10)};
-    }
-    e.AddGroupingPolicies(g_policies);
-    casbin::DataList params = {"user50001", "data1500", "read"};
-    for (auto _ : state)
-    {
-        e.Enforce(params);
-    }
-}
-
-// BENCHMARK(BenchmarkCachedRBACModelLarge);
+BENCHMARK(BenchmarkCachedRBACModelLoop);
 
 static void BenchmarkCachedRBACModelWithResourceRoles(benchmark::State& state) {
     casbin::CachedEnforcer e(rbac_with_resource_roles_model_path, rbac_with_resource_roles_policy_path, false);

--- a/tests/benchmarks/management_api_b.cpp
+++ b/tests/benchmarks/management_api_b.cpp
@@ -49,7 +49,7 @@ static void BenchmarkVectorOperations(benchmark::State& state) {
 
 BENCHMARK(BenchmarkVectorOperations);
 
-static void BenchmarkHasPolicySmall(benchmark::State& state) {
+static void BenchmarkHasPolicyLoop(benchmark::State& state) {
     casbin::Enforcer e(basic_model_path);
 
     // 100 roles, 10 resources.
@@ -60,37 +60,9 @@ static void BenchmarkHasPolicySmall(benchmark::State& state) {
         params = { "user" + std::to_string(GetRandom100()), "data" + std::to_string(GetRandom100()/10), "read" }, e.HasPolicy(params);
 }
 
-BENCHMARK(BenchmarkHasPolicySmall);
+BENCHMARK(BenchmarkHasPolicyLoop);
 
-static void BenchmarkHasPolicyMedium(benchmark::State& state) {
-    casbin::Enforcer e(basic_model_path);
-
-    // 1000 roles, 100 resources.
-    // std::vector<std::vector<std::string>> p_policies(1000);
-    for (int i = 0; i < 1000; ++i)
-        params = {"user" + std::to_string(i), "data" + std::to_string(i / 10), "read"}, e.AddPolicy(params);
-    // e.AddPolicies(p_policies);
-    for (auto _ : state)
-        params = { "user" + std::to_string(GetRandom1000()), "data" + std::to_string(GetRandom1000()/10), "read" }, e.HasPolicy(params);
-}
-
-BENCHMARK(BenchmarkHasPolicyMedium);
-
-static void BenchmarkHasPolicyLarge(benchmark::State& state) {
-    casbin::Enforcer e(basic_model_path);
-
-    // 10000 roles, 1000 resources.
-    for (int i = 0; i < 10000; i++)
-        params = {"user" + std::to_string(i), "data" + std::to_string(i / 10), "read"}, e.AddPolicy(params);
-
-    for(auto _ : state) {
-        params = {"user" + std::to_string(GetRandom10000()), "data" + std::to_string(GetRandom10000()/10), "read"}, e.HasPolicy(params);
-    }
-}
-
-BENCHMARK(BenchmarkHasPolicyLarge);
-
-static void BenchmarkAddPolicySmall(benchmark::State& state) {
+static void BenchmarkAddPolicyLoop(benchmark::State& state) {
     casbin::Enforcer e(basic_model_path);
 
     // 100 roles, 10 resources.
@@ -101,38 +73,9 @@ static void BenchmarkAddPolicySmall(benchmark::State& state) {
         params = {"user" + std::to_string(GetRandom100() + 100), "data" + std::to_string((GetRandom100() + 100)/10), "read"}, e.AddPolicy(params);
 }
 
-BENCHMARK(BenchmarkAddPolicySmall);
+BENCHMARK(BenchmarkAddPolicyLoop);
 
-static void BenchmarkAddPolicyMedium(benchmark::State& state) {
-    casbin::Enforcer e(basic_model_path);
-
-    // 1000 roles, 100 resources.
-    for(int i = 0; i < 1000; ++i)
-        params = {"user" + std::to_string(i), "data" + std::to_string(i / 10), "read"}, e.AddPolicy(params);
-    // _, err := e.AddPolicies(pPolicies)
-
-    for(auto _ : state) {
-        params = {"user" + std::to_string(GetRandom1000() + 1000), "data" + std::to_string((GetRandom1000() + 1000) / 10), "read"}, e.AddPolicy(params);
-    }
-}
-
-BENCHMARK(BenchmarkAddPolicyMedium);
-
-static void BenchmarkAddPolicyLarge(benchmark::State& state) {
-    casbin::Enforcer e(basic_model_path);
-
-    // 10000 roles, 1000 resources.
-    for(int i = 0; i < 10000; ++i)
-        params = { "user" + std::to_string(i), "data" + std::to_string(i/10), "read" }, e.AddPolicy(params);
-
-    for(auto _ : state) {
-        params = { "user" + std::to_string(GetRandom10000() + 10000), "data" + std::to_string((GetRandom10000() + 10000) / 10), "read" }, e.AddPolicy(params);
-    }
-}
-
-BENCHMARK(BenchmarkAddPolicyLarge);
-
-static void BenchmarkRemovePolicySmall(benchmark::State& state) {
+static void BenchmarkRemovePolicyLoop(benchmark::State& state) {
     casbin::Enforcer e(basic_model_path);
 
     // 100 roles, 10 resources.
@@ -143,30 +86,5 @@ static void BenchmarkRemovePolicySmall(benchmark::State& state) {
         params = { "user" + std::to_string(GetRandom100()), "data" + std::to_string(GetRandom100() / 10), "read" }, e.RemovePolicy(params);
 }
 
-BENCHMARK(BenchmarkRemovePolicySmall);
+BENCHMARK(BenchmarkRemovePolicyLoop);
 
-static void BenchmarkRemovePolicyMedium(benchmark::State& state) {
-    casbin::Enforcer e(basic_model_path);
-
-    // 1000 roles, 100 resources.
-    for(int i = 0; i < 1000; ++i)
-        params = {"user" + std::to_string(i), "data" + std::to_string(i / 10), "read"}, e.AddPolicy(params);
-
-    for(auto _ : state)
-        params = { "user" + std::to_string(GetRandom1000()), "data" + std::to_string(GetRandom1000() / 10), "read" }, e.RemovePolicy(params);
-}
-
-BENCHMARK(BenchmarkRemovePolicyMedium);
-
-static void BenchmarkRemovePolicyLarge(benchmark::State& state) {
-    casbin::Enforcer e(basic_model_path);
-
-    // 10000 roles, 1000 resources.
-    for(int i = 0; i < 10000; ++i)
-        params = { "user" + std::to_string(i), "data" + std::to_string(i / 10), "read" }, e.AddPolicy(params);
-
-    for(auto _ : state)
-        params = { "user" + std::to_string(GetRandom10000()), "data" + std::to_string(GetRandom1000()), "read" }, e.RemovePolicy(params);
-}
-
-BENCHMARK(BenchmarkRemovePolicyLarge);

--- a/tests/benchmarks/management_api_b.cpp
+++ b/tests/benchmarks/management_api_b.cpp
@@ -49,7 +49,7 @@ static void BenchmarkVectorOperations(benchmark::State& state) {
 
 BENCHMARK(BenchmarkVectorOperations);
 
-static void BenchmarkHasPolicyLoop(benchmark::State& state) {
+static void BenchmarkHasPolicySmall(benchmark::State& state) {
     casbin::Enforcer e(basic_model_path);
 
     // 100 roles, 10 resources.
@@ -60,9 +60,37 @@ static void BenchmarkHasPolicyLoop(benchmark::State& state) {
         params = { "user" + std::to_string(GetRandom100()), "data" + std::to_string(GetRandom100()/10), "read" }, e.HasPolicy(params);
 }
 
-BENCHMARK(BenchmarkHasPolicyLoop);
+BENCHMARK(BenchmarkHasPolicySmall);
 
-static void BenchmarkAddPolicyLoop(benchmark::State& state) {
+static void BenchmarkHasPolicyMedium(benchmark::State& state) {
+    casbin::Enforcer e(basic_model_path);
+
+    // 1000 roles, 100 resources.
+    // std::vector<std::vector<std::string>> p_policies(1000);
+    for (int i = 0; i < 1000; ++i)
+        params = {"user" + std::to_string(i), "data" + std::to_string(i / 10), "read"}, e.AddPolicy(params);
+    // e.AddPolicies(p_policies);
+    for (auto _ : state)
+        params = { "user" + std::to_string(GetRandom1000()), "data" + std::to_string(GetRandom1000()/10), "read" }, e.HasPolicy(params);
+}
+
+// BENCHMARK(BenchmarkHasPolicyMedium);
+
+static void BenchmarkHasPolicyLarge(benchmark::State& state) {
+    casbin::Enforcer e(basic_model_path);
+
+    // 10000 roles, 1000 resources.
+    for (int i = 0; i < 10000; i++)
+        params = {"user" + std::to_string(i), "data" + std::to_string(i / 10), "read"}, e.AddPolicy(params);
+
+    for(auto _ : state) {
+        params = {"user" + std::to_string(GetRandom10000()), "data" + std::to_string(GetRandom10000()/10), "read"}, e.HasPolicy(params);
+    }
+}
+
+// BENCHMARK(BenchmarkHasPolicyLarge);
+
+static void BenchmarkAddPolicySmall(benchmark::State& state) {
     casbin::Enforcer e(basic_model_path);
 
     // 100 roles, 10 resources.
@@ -73,9 +101,38 @@ static void BenchmarkAddPolicyLoop(benchmark::State& state) {
         params = {"user" + std::to_string(GetRandom100() + 100), "data" + std::to_string((GetRandom100() + 100)/10), "read"}, e.AddPolicy(params);
 }
 
-BENCHMARK(BenchmarkAddPolicyLoop);
+BENCHMARK(BenchmarkAddPolicySmall);
 
-static void BenchmarkRemovePolicyLoop(benchmark::State& state) {
+static void BenchmarkAddPolicyMedium(benchmark::State& state) {
+    casbin::Enforcer e(basic_model_path);
+
+    // 1000 roles, 100 resources.
+    for(int i = 0; i < 1000; ++i)
+        params = {"user" + std::to_string(i), "data" + std::to_string(i / 10), "read"}, e.AddPolicy(params);
+    // _, err := e.AddPolicies(pPolicies)
+
+    for(auto _ : state) {
+        params = {"user" + std::to_string(GetRandom1000() + 1000), "data" + std::to_string((GetRandom1000() + 1000) / 10), "read"}, e.AddPolicy(params);
+    }
+}
+
+// BENCHMARK(BenchmarkAddPolicyMedium);
+
+static void BenchmarkAddPolicyLarge(benchmark::State& state) {
+    casbin::Enforcer e(basic_model_path);
+
+    // 10000 roles, 1000 resources.
+    for(int i = 0; i < 10000; ++i)
+        params = { "user" + std::to_string(i), "data" + std::to_string(i/10), "read" }, e.AddPolicy(params);
+
+    for(auto _ : state) {
+        params = { "user" + std::to_string(GetRandom10000() + 10000), "data" + std::to_string((GetRandom10000() + 10000) / 10), "read" }, e.AddPolicy(params);
+    }
+}
+
+// BENCHMARK(BenchmarkAddPolicyLarge);
+
+static void BenchmarkRemovePolicySmall(benchmark::State& state) {
     casbin::Enforcer e(basic_model_path);
 
     // 100 roles, 10 resources.
@@ -86,5 +143,31 @@ static void BenchmarkRemovePolicyLoop(benchmark::State& state) {
         params = { "user" + std::to_string(GetRandom100()), "data" + std::to_string(GetRandom100() / 10), "read" }, e.RemovePolicy(params);
 }
 
-BENCHMARK(BenchmarkRemovePolicyLoop);
+BENCHMARK(BenchmarkRemovePolicySmall);
+
+static void BenchmarkRemovePolicyMedium(benchmark::State& state) {
+    casbin::Enforcer e(basic_model_path);
+
+    // 1000 roles, 100 resources.
+    for(int i = 0; i < 1000; ++i)
+        params = {"user" + std::to_string(i), "data" + std::to_string(i / 10), "read"}, e.AddPolicy(params);
+
+    for(auto _ : state)
+        params = { "user" + std::to_string(GetRandom1000()), "data" + std::to_string(GetRandom1000() / 10), "read" }, e.RemovePolicy(params);
+}
+
+// BENCHMARK(BenchmarkRemovePolicyMedium);
+
+static void BenchmarkRemovePolicyLarge(benchmark::State& state) {
+    casbin::Enforcer e(basic_model_path);
+
+    // 10000 roles, 1000 resources.
+    for(int i = 0; i < 10000; ++i)
+        params = { "user" + std::to_string(i), "data" + std::to_string(i / 10), "read" }, e.AddPolicy(params);
+
+    for(auto _ : state)
+        params = { "user" + std::to_string(GetRandom10000()), "data" + std::to_string(GetRandom1000()), "read" }, e.RemovePolicy(params);
+}
+
+// BENCHMARK(BenchmarkRemovePolicyLarge);
 

--- a/tests/benchmarks/model_b.cpp
+++ b/tests/benchmarks/model_b.cpp
@@ -58,7 +58,7 @@ static void BenchmarkRBACModel(benchmark::State& state) {
 
 BENCHMARK(BenchmarkRBACModel);
 
-static void BenchmarkRBACModelSmall(benchmark::State& state) {
+static void BenchmarkRBACModelLoop(benchmark::State& state) {
     casbin::Enforcer e(rbac_model_path);
 
     // 100 roles, 10 resources.
@@ -74,44 +74,7 @@ static void BenchmarkRBACModelSmall(benchmark::State& state) {
         e.Enforce(params);
 }
 
-BENCHMARK(BenchmarkRBACModelSmall);
-
-static void BenchmarkRBACModelMedium(benchmark::State& state) {
-    casbin::Enforcer e(rbac_model_path);
-
-    // 1000 roles, 100 resources.
-    for (int i = 0; i < 1000; ++i)
-        e.AddPolicy({"group" + std::to_string(i), "data" + std::to_string(i / 10), "read"});
-
-    // 10000 users.
-    for (int i = 0; i < 10000; ++i)
-        e.AddGroupingPolicy({"user" + std::to_string(i), "group" + std::to_string(i / 10)});
-
-    casbin::DataList params = {"user5001", "data99", "read"};
-    for (auto _ : state)
-        e.Enforce(params);
-}
-
-BENCHMARK(BenchmarkRBACModelMedium);
-
-static void BenchmarkRBACModelLarge(benchmark::State& state) {
-    casbin::Enforcer e(rbac_model_path);
-
-    // 10000 roles, 1000 resources.
-    for(int i = 0; i < 10000; ++i)
-        e.AddPolicy({"group" + std::to_string(i), "data" + std::to_string(i / 10), "read"});
-
-    // 100000 users.
-    for(int i = 0; i < 100000; i++)
-        e.AddGroupingPolicy({"user" + std::to_string(i), "group" + std::to_string(i / 10)});
-
-    casbin::DataList params = {"user50001", "data999", "read"};
-
-    for(auto _ : state)
-        e.Enforce(params);
-}
-
-// BENCHMARK(BenchmarkRBACModelLarge);
+BENCHMARK(BenchmarkRBACModelLoop);
 
 static void BenchmarkRBACModelWithResourceRoles(benchmark::State& state) {
     casbin::Enforcer e(rbac_with_resource_roles_model_path, rbac_with_resource_roles_policy_path);
@@ -120,7 +83,7 @@ static void BenchmarkRBACModelWithResourceRoles(benchmark::State& state) {
         e.Enforce(params);
 }
 
-// BENCHMARK(BenchmarkRBACModelWithResourceRoles);
+BENCHMARK(BenchmarkRBACModelWithResourceRoles);
 
 static void BenchmarkRBACModelWithDomains(benchmark::State& state) {
     casbin::Enforcer e(rbac_with_domains_model_path, rbac_with_domains_policy_path);

--- a/tests/benchmarks/model_b.cpp
+++ b/tests/benchmarks/model_b.cpp
@@ -58,7 +58,7 @@ static void BenchmarkRBACModel(benchmark::State& state) {
 
 BENCHMARK(BenchmarkRBACModel);
 
-static void BenchmarkRBACModelLoop(benchmark::State& state) {
+static void BenchmarkRBACModelSmall(benchmark::State& state) {
     casbin::Enforcer e(rbac_model_path);
 
     // 100 roles, 10 resources.
@@ -74,7 +74,44 @@ static void BenchmarkRBACModelLoop(benchmark::State& state) {
         e.Enforce(params);
 }
 
-BENCHMARK(BenchmarkRBACModelLoop);
+BENCHMARK(BenchmarkRBACModelSmall);
+
+static void BenchmarkRBACModelMedium(benchmark::State& state) {
+    casbin::Enforcer e(rbac_model_path);
+
+    // 1000 roles, 100 resources.
+    for (int i = 0; i < 1000; ++i)
+        e.AddPolicy({"group" + std::to_string(i), "data" + std::to_string(i / 10), "read"});
+
+    // 10000 users.
+    for (int i = 0; i < 10000; ++i)
+        e.AddGroupingPolicy({"user" + std::to_string(i), "group" + std::to_string(i / 10)});
+
+    casbin::DataList params = {"user5001", "data99", "read"};
+    for (auto _ : state)
+        e.Enforce(params);
+}
+
+// BENCHMARK(BenchmarkRBACModelMedium);
+
+static void BenchmarkRBACModelLarge(benchmark::State& state) {
+    casbin::Enforcer e(rbac_model_path);
+
+    // 10000 roles, 1000 resources.
+    for(int i = 0; i < 10000; ++i)
+        e.AddPolicy({"group" + std::to_string(i), "data" + std::to_string(i / 10), "read"});
+
+    // 100000 users.
+    for(int i = 0; i < 100000; i++)
+        e.AddGroupingPolicy({"user" + std::to_string(i), "group" + std::to_string(i / 10)});
+
+    casbin::DataList params = {"user50001", "data999", "read"};
+
+    for(auto _ : state)
+        e.Enforce(params);
+}
+
+// BENCHMARK(BenchmarkRBACModelLarge);
 
 static void BenchmarkRBACModelWithResourceRoles(benchmark::State& state) {
     casbin::Enforcer e(rbac_with_resource_roles_model_path, rbac_with_resource_roles_policy_path);

--- a/tests/benchmarks/role_manager_b.cpp
+++ b/tests/benchmarks/role_manager_b.cpp
@@ -23,7 +23,7 @@
 static std::vector<std::string> params(3);
 static std::vector<std::string> g_params(2);
 
-static void BenchmarkRoleManagerSmall(benchmark::State& state) {
+static void BenchmarkRoleManagerLoop(benchmark::State& state) {
     casbin::Enforcer e(rbac_model_path);
     // Do not rebuild the role inheritance relations for every AddGroupingPolicy() call.
     e.EnableAutoBuildRoleLinks(false);
@@ -44,54 +44,4 @@ static void BenchmarkRoleManagerSmall(benchmark::State& state) {
     }
 }
 
-BENCHMARK(BenchmarkRoleManagerSmall);
-
-static void BenchmarkRoleManagerMedium(benchmark::State& state) {
-    casbin::Enforcer e(rbac_model_path);
-    // Do not rebuild the role inheritance relations for every AddGroupingPolicy() call.
-    e.EnableAutoBuildRoleLinks(false);
-
-    // 1000 roles, 100 resources.
-    
-    for (int i = 0; i < 1000; ++i)
-        params = {"group" + std::to_string(i), "data" + std::to_string(i / 10), "read"}, e.AddPolicy(params);
-
-    // 10000 users.
-    
-    for (int i = 0; i < 10000; ++i)
-        g_params = {"user" + std::to_string(i), "group" + std::to_string(i / 10)}, e.AddGroupingPolicy(g_params);
-
-    e.BuildRoleLinks();
-
-    auto rm = e.GetRoleManager();
-
-    for(auto _ : state) {
-        for(int j = 0; j < 1000; ++j)
-            rm->HasLink("user501", "group" + std::to_string(j));
-    }
-}
-
-BENCHMARK(BenchmarkRoleManagerMedium);
-
-static void BenchmarkRoleManagerLarge(benchmark::State& state) {
-    casbin::Enforcer e(rbac_model_path);
-
-    // 10000 roles, 1000 resources.
-    
-    for (int i = 0; i < 10000; ++i)
-        params = {"group" + std::to_string(i), "data" + std::to_string(i / 10), "read"}, e.AddPolicy(params);
-
-    // 100000 users.
-    
-    for (int i = 0; i < 100000; ++i)
-        g_params = {"user" + std::to_string(i), "group" + std::to_string(i / 10)}, e.AddGroupingPolicy(g_params);
-
-    auto rm = e.GetRoleManager();
-
-    for(auto _ : state) {
-        for(int j = 0; j < 10000; ++j)
-            rm->HasLink("user501", "group" + std::to_string(j));
-    }
-}
-
-// BENCHMARK(BenchmarkRoleManagerLarge);
+BENCHMARK(BenchmarkRoleManagerLoop);

--- a/tests/benchmarks/role_manager_b.cpp
+++ b/tests/benchmarks/role_manager_b.cpp
@@ -23,7 +23,7 @@
 static std::vector<std::string> params(3);
 static std::vector<std::string> g_params(2);
 
-static void BenchmarkRoleManagerLoop(benchmark::State& state) {
+static void BenchmarkRoleManagerSmall(benchmark::State& state) {
     casbin::Enforcer e(rbac_model_path);
     // Do not rebuild the role inheritance relations for every AddGroupingPolicy() call.
     e.EnableAutoBuildRoleLinks(false);
@@ -44,4 +44,54 @@ static void BenchmarkRoleManagerLoop(benchmark::State& state) {
     }
 }
 
-BENCHMARK(BenchmarkRoleManagerLoop);
+BENCHMARK(BenchmarkRoleManagerSmall);
+
+static void BenchmarkRoleManagerMedium(benchmark::State& state) {
+    casbin::Enforcer e(rbac_model_path);
+    // Do not rebuild the role inheritance relations for every AddGroupingPolicy() call.
+    e.EnableAutoBuildRoleLinks(false);
+
+    // 1000 roles, 100 resources.
+    
+    for (int i = 0; i < 1000; ++i)
+        params = {"group" + std::to_string(i), "data" + std::to_string(i / 10), "read"}, e.AddPolicy(params);
+
+    // 10000 users.
+    
+    for (int i = 0; i < 10000; ++i)
+        g_params = {"user" + std::to_string(i), "group" + std::to_string(i / 10)}, e.AddGroupingPolicy(g_params);
+
+    e.BuildRoleLinks();
+
+    auto rm = e.GetRoleManager();
+
+    for(auto _ : state) {
+        for(int j = 0; j < 1000; ++j)
+            rm->HasLink("user501", "group" + std::to_string(j));
+    }
+}
+
+// BENCHMARK(BenchmarkRoleManagerMedium);
+
+static void BenchmarkRoleManagerLarge(benchmark::State& state) {
+    casbin::Enforcer e(rbac_model_path);
+
+    // 10000 roles, 1000 resources.
+    
+    for (int i = 0; i < 10000; ++i)
+        params = {"group" + std::to_string(i), "data" + std::to_string(i / 10), "read"}, e.AddPolicy(params);
+
+    // 100000 users.
+    
+    for (int i = 0; i < 100000; ++i)
+        g_params = {"user" + std::to_string(i), "group" + std::to_string(i / 10)}, e.AddGroupingPolicy(g_params);
+
+    auto rm = e.GetRoleManager();
+
+    for(auto _ : state) {
+        for(int j = 0; j < 10000; ++j)
+            rm->HasLink("user501", "group" + std::to_string(j));
+    }
+}
+
+// BENCHMARK(BenchmarkRoleManagerLarge);


### PR DESCRIPTION
<!--
    We follow semantic pull requests. Make sure you sign-off and format every commit message
    as well as the PR title as specified in 
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

    Eg. feat: New feature name,
    fix: Some error, etc.
-->

Fix: https://github.com/casbin/casbin-cpp/issues/155

### Description

There were some loops for benchmark tests used in some functions that could take long time, e.g.,
```
BenchmarkRBACModelSmall() 
BenchmarkRBACModelMedium()
BenchmarkRBACModelLarge()
```
Except the number of iterations of loop, these functions were almost the same.
I deleted those functions called *Medium() and *Large(), then replaced the name of *Small() by *Loop(), it can save a lot of time.

### Screenshots/Testimonials

![image](https://raw.githubusercontent.com/noob20000405/readme_pic/master/casbin/p1.png)
