### PR TITLE
fix: fix FileAdapter.SavePolicy()

### DIFF
--- a/casbin/persist/file_adapter/file_adapter.cpp
+++ b/casbin/persist/file_adapter/file_adapter.cpp
@@ -20,6 +20,10 @@ FileAdapter :: FileAdapter(std::string file_path) {
     this->filtered = false;
 }
 
+std::shared_ptr<casbin::FileAdapter> FileAdapter::NewFileAdapter(std::string file_path) {
+    return std::make_shared<FileAdapter>(file_path);
+}
+
 // LoadPolicy loads all policy rules from the storage.
 void FileAdapter :: LoadPolicy(const std::shared_ptr<Model>& model) {
     if (this->file_path == "")
@@ -36,7 +40,7 @@ void FileAdapter :: SavePolicy(const std::shared_ptr<Model>& model) {
 
     std::string tmp;
 
-    for (std::unordered_map<std::string, std::shared_ptr<Assertion>> :: iterator it = model->m["p"].assertion_map.begin() ; it != model->m["p"].assertion_map.begin() ; it++){
+    for (std::unordered_map<std::string, std::shared_ptr<Assertion>> :: iterator it = model->m["p"].assertion_map.begin() ; it != model->m["p"].assertion_map.end() ; it++){
         for (int i = 0 ; i < it->second->policy.size() ; i++){
             tmp += it->first + ", ";
             tmp += ArrayToString(it->second->policy[i]);
@@ -44,7 +48,7 @@ void FileAdapter :: SavePolicy(const std::shared_ptr<Model>& model) {
         }
     }
 
-    for (std::unordered_map <std::string, std::shared_ptr<Assertion>> :: iterator it = model->m["g"].assertion_map.begin() ; it != model->m["g"].assertion_map.begin() ; it++){
+    for (std::unordered_map <std::string, std::shared_ptr<Assertion>> :: iterator it = model->m["g"].assertion_map.begin() ; it != model->m["g"].assertion_map.end() ; it++){
         for (int i = 0 ; i < it->second->policy.size() ; i++){
             tmp += it->first + ", ";
             tmp += ArrayToString(it->second->policy[i]);
@@ -74,14 +78,18 @@ void FileAdapter :: LoadPolicyFile(const std::shared_ptr<Model>& model, std::fun
 
 void FileAdapter :: SavePolicyFile(std::string text) {
     std::ofstream out_file;
-    out_file.open(this->file_path, std::ios::out);
+
     try {
         out_file.open(this->file_path, std::ios::out);
     } catch (const std::ifstream::failure e) {
         throw IOException("Cannot open file.");
     }
 
-    out_file<<text;
+    if (out_file.is_open() == false) {
+        throw IOException("Don't exit adapter file");
+    }
+
+    out_file << text;
 
     out_file.close();
 }

--- a/casbin/persist/file_adapter/file_adapter.h
+++ b/casbin/persist/file_adapter/file_adapter.h
@@ -13,6 +13,8 @@ class FileAdapter : virtual public Adapter {
         // NewAdapter is the constructor for Adapter.
         FileAdapter(std::string file_path);
 
+        static std::shared_ptr<FileAdapter> NewFileAdapter(std::string file_path);
+
         // LoadPolicy loads all policy rules from the storage.
         void LoadPolicy(const std::shared_ptr<Model>& model);
 

--- a/casbin/util/array_to_string.cpp
+++ b/casbin/util/array_to_string.cpp
@@ -25,10 +25,10 @@
 namespace casbin {
 
 std::string ArrayToString(const std::vector<std::string>& arr){
-    std::string res = arr[0];
+    std::string res = "";
     for (const std::string& it : arr)
         res += ", " + it;
-    return res;
+    return res.substr(2);
 }
 
 } // namespace casbin

--- a/include/casbin/casbin_helpers.h
+++ b/include/casbin/casbin_helpers.h
@@ -434,6 +434,8 @@ namespace casbin {
         // NewAdapter is the constructor for Adapter.
         FileAdapter(std::string file_path);
 
+        static std::shared_ptr<FileAdapter> NewFileAdapter(std::string file_path);
+
         // LoadPolicy loads all policy rules from the storage.
         void LoadPolicy(const std::shared_ptr<Model>& model);
 


### PR DESCRIPTION
<!--
    We follow semantic pull requests. Make sure you sign-off and format every commit message
    as well as the PR title as specified in 
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

    Eg. feat: New feature name,
    fix: Some error, etc.
-->

### Description
+ Fix `FileAdapter.SavePolicy()`
+ Add a new FileAdapter interface to use in python like [casbin::Config](https://github.com/casbin/casbin-cpp/blob/abaa2174f0a4c6df2a25c21c388c15939f472655/casbin/config/config.h#L55).
+ Fix `ArrayToString(const std::vector<std::string>& arr)`
  + `arr` usually be a line of policy keys without `p` or `g`, (e.g. `arr = {"alice", "data1", "read"}`).
  + Before `ArrayToString(const std::vector<std::string>& arr)`, `arr` will return `alice,  alice, data1, read`. `alice` will generate twice.


