### PR TITLE
feat: add json parser to build attribute in duktape

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -70,6 +70,7 @@ target_link_libraries(pycasbin
     PRIVATE
         pybind11::module
         casbin
+        nlohmann_json::nlohmann_json
 )
 
 if(WIN32)

--- a/casbin/CMakeLists.txt
+++ b/casbin/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(casbin STATIC ${CASBIN_SOURCE_FILES})
 
 target_precompile_headers(casbin PRIVATE pch.h)
 target_include_directories(casbin PRIVATE ${CASBIN_SOURCE_DIR})
+target_link_libraries(casbin PRIVATE nlohmann_json::nlohmann_json)
 
 set_target_properties(casbin PROPERTIES 
     PREFIX ""

--- a/casbin/data_types.h
+++ b/casbin/data_types.h
@@ -18,6 +18,7 @@
 #include <vector>
 #include <initializer_list>
 #include <unordered_map>
+#include <nlohmann/json.hpp>
 #include "abac_data.h"
 
 namespace casbin {

--- a/casbin/data_types.h
+++ b/casbin/data_types.h
@@ -23,7 +23,7 @@
 
 namespace casbin {
 
-typedef std::variant<std::string, std::shared_ptr<ABACData>> Data;
+typedef std::variant<std::string, std::shared_ptr<ABACData>, std::shared_ptr<nlohmann::json>> Data;
 typedef std::vector<Data> DataVector;
 typedef std::initializer_list<Data> DataList;
 typedef std::unordered_map<std::string, Data> DataMap;

--- a/casbin/enforcer.cpp
+++ b/casbin/enforcer.cpp
@@ -501,6 +501,14 @@ bool Enforcer::EnforceWithMatcher(const std::string& matcher, const DataList& pa
                 else
                     throw CasbinEnforcerException("Not a valid type");
             }
+        } else if (const auto json_param = std::get_if<std::shared_ptr<nlohmann::json>>(&param)) {
+            
+            auto data_ptr = *json_param;
+            std::string token_name = r_tokens[i].substr(2, r_tokens[i].size() - 2);
+
+            PushObject(scope, token_name);
+            PushObjectPropFromJson(scope, *data_ptr, token_name);
+            PushObjectPropToObject(scope, "r", token_name);
         }
         ++i;
     }
@@ -556,7 +564,16 @@ bool Enforcer::EnforceWithMatcher(const std::string& matcher, const DataVector& 
                 else
                     throw CasbinEnforcerException("Not a valid type");
             }
+        } else if (const auto json_param = std::get_if<std::shared_ptr<nlohmann::json>>(&param)) {
+            
+            auto data_ptr = *json_param;
+            std::string token_name = r_tokens[i].substr(2, r_tokens[i].size() - 2);
+
+            PushObject(scope, token_name);
+            PushObjectPropFromJson(scope, *data_ptr, token_name);
+            PushObjectPropToObject(scope, "r", token_name);
         }
+
         ++i;
     }
 
@@ -601,7 +618,14 @@ bool Enforcer::EnforceWithMatcher(const std::string& matcher, const DataMap& par
                 else
                     throw CasbinEnforcerException("Not a valid type");
             }
+        } else if (const auto json_param = std::get_if<std::shared_ptr<nlohmann::json>>(&param_data)) {
+            
+            auto data_ptr = *json_param;
+            PushObject(scope, param_name);
+            PushObjectPropFromJson(scope, *data_ptr, param_name);
+            PushObjectPropToObject(scope, "r", param_name);
         }
+
     }
 
     bool result = m_enforce(matcher, scope);

--- a/casbin/model/scope_config.cpp
+++ b/casbin/model/scope_config.cpp
@@ -194,34 +194,34 @@ void PushObjectPropToObject(Scope scope, std::string obj, std::string identifier
     duk_eval_string_noresult(scope, (obj+"len += 1;").c_str());
 }
 
-void PushObjectPropFromJson(Scope scope, nlohmann::json& j, std::string j_name) {
+void PushObjectPropFromJson(Scope scope, nlohmann::json& j, std::string objName) {
     if (j.is_null()) {
         return;
     }
 
-    for (auto& cur_j: j.items()) {
-        auto key = cur_j.key();
-        auto value = cur_j.value();
+    for (auto& curJson: j.items()) {
+        auto key = curJson.key();
+        auto value = curJson.value();
         if (value.is_object()) {
 
-            auto next_json_name = key + "__";
-            PushObject(scope, next_json_name);
+            auto nextJsonName = key + "__";
+            PushObject(scope, nextJsonName);
 
-            PushObjectPropFromJson(scope, value, next_json_name); 
+            PushObjectPropFromJson(scope, value, nextJsonName); 
 
-            duk_get_global_string(scope, j_name.c_str());
-            duk_get_global_string(scope, next_json_name.c_str());
+            duk_get_global_string(scope, objName.c_str());
+            duk_get_global_string(scope, nextJsonName.c_str());
             duk_put_prop_string(scope, -2, key.c_str());
         } else if (value.is_number_float()) {
-            PushDoublePropToObject(scope, j_name, value, key);
+            PushDoublePropToObject(scope, objName, value, key);
         } else if (value.is_number_integer()) {
-            PushIntPropToObject(scope, j_name, value, key);
+            PushIntPropToObject(scope, objName, value, key);
         } else if (value.is_string()) {
-            PushStringPropToObject(scope, j_name, value, key);
+            PushStringPropToObject(scope, objName, value, key);
         } else if (value.is_boolean()) {
-            PushBooleanPropToObject(scope, j_name, value, key);
+            PushBooleanPropToObject(scope, objName, value, key);
         } else {
-            throw IllegalArgumentException("Unsupport json value type");
+            throw IllegalArgumentException("Unsupported json value type");
         }
     }
 }

--- a/casbin/model/scope_config.h
+++ b/casbin/model/scope_config.h
@@ -69,6 +69,7 @@ void PushDoublePropToObject(Scope scope, std::string obj, double d, std::string 
 void PushStringPropToObject(Scope scope, std::string obj, std::string s, std::string identifier);
 void PushPointerPropToObject(Scope scope, std::string obj, void * ptr, std::string identifier);
 void PushObjectPropToObject(Scope scope, std::string obj, std::string identifier);
+void PushObjectPropFromJson(Scope scope, nlohmann::json& j, std::string j_name);
 Type CheckType(Scope scope);
 bool FetchIdentifier(Scope scope, std::string identifier);
 unsigned int Size(Scope scope);

--- a/cmake/modules/FindExtPackages.cmake
+++ b/cmake/modules/FindExtPackages.cmake
@@ -24,6 +24,8 @@ set(CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY ON CACHE BOOL
 ###############################################################################
 ### Packages and versions ###
 
+find_package(json 3.7.3 REQUIRED)
+
 if(CASBIN_BUILD_TEST)
     # googletest
     # https://github.com/google/googletest

--- a/cmake/modules/Findjson.cmake
+++ b/cmake/modules/Findjson.cmake
@@ -1,0 +1,28 @@
+
+#  Copyright 2021 The casbin Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+include(FetchContent)
+
+FetchContent_Declare(json
+  GIT_REPOSITORY https://github.com/nlohmann/json.git
+  GIT_TAG v3.7.3)
+
+set(JSON_BuildTests OFF CACHE INTERNAL "")
+FetchContent_GetProperties(json)
+FetchContent_MakeAvailable(json)
+
+if(NOT json_POPULATED)
+  FetchContent_Populate(json)
+  add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()

--- a/include/casbin/casbin_helpers.h
+++ b/include/casbin/casbin_helpers.h
@@ -540,6 +540,7 @@ namespace casbin {
     void PushStringPropToObject(Scope scope, std::string obj, std::string s, std::string identifier);
     void PushPointerPropToObject(Scope scope, std::string obj, void * ptr, std::string identifier);
     void PushObjectPropToObject(Scope scope, std::string obj, std::string identifier);
+    void PushObjectPropFromJson(Scope scope, nlohmann::json& j, std::string j_name);
     Type CheckType(Scope scope);
     bool FetchIdentifier(Scope scope, std::string identifier);
     unsigned int Size(Scope scope);

--- a/include/casbin/casbin_types.h
+++ b/include/casbin/casbin_types.h
@@ -25,6 +25,7 @@
 #include <initializer_list>
 #include <memory>
 #include <unordered_map>
+#include <nlohmann/json.hpp>
 
 namespace casbin {
 

--- a/include/casbin/casbin_types.h
+++ b/include/casbin/casbin_types.h
@@ -122,7 +122,7 @@ namespace casbin {
      */
     const std::shared_ptr<ABACData> GetDataObject(const AttributeMap& attribs);
 
-    typedef std::variant<std::string, std::shared_ptr<ABACData>> Data;
+    typedef std::variant<std::string, std::shared_ptr<ABACData>, std::shared_ptr<nlohmann::json>> Data;
     typedef std::vector<Data> DataVector;
     typedef std::initializer_list<Data> DataList;
     typedef std::unordered_map<std::string, Data> DataMap;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ if(CASBIN_BUILD_TEST)
     PRIVATE
     gtest_main
     casbin
+    nlohmann_json::nlohmann_json
   )
 
   include(GoogleTest)

--- a/tests/benchmarks/CMakeLists.txt
+++ b/tests/benchmarks/CMakeLists.txt
@@ -41,4 +41,5 @@ target_link_libraries(
         PRIVATE
     benchmark
     casbin
+    nlohmann_json::nlohmann_json
 )

--- a/tests/config_path.h
+++ b/tests/config_path.h
@@ -51,3 +51,5 @@ static const std::string keymatch_policy_path = relative_path + "/examples/keyma
 
 static const std::string priority_model_path = relative_path + "/examples/priority_model.conf";
 static const std::string priority_policy_path = relative_path + "/examples/priority_policy.csv";
+
+static const std::string abac_model_path = relative_path + "/examples/abac_model.conf";

--- a/tests/enforcer_test.cpp
+++ b/tests/enforcer_test.cpp
@@ -19,7 +19,6 @@
 #include <gtest/gtest.h>
 #include <casbin/casbin.h>
 #include "config_path.h"
-#include <nlohmann/json.hpp>
 
 namespace {
 
@@ -121,7 +120,7 @@ TEST(TestEnforcer, JsonData) {
     casbin::Scope scope = casbin::InitializeScope();
     casbin::PushObject(scope, "r");
 
-    json myjson = {
+    json myJson = {
             {"DoubleCase", 3.141},
             {"IntegerCase", 2},
             {"BoolenCase", true},
@@ -138,7 +137,7 @@ TEST(TestEnforcer, JsonData) {
             },
         };
 
-    casbin::PushObjectPropFromJson(scope, myjson, "r");
+    casbin::PushObjectPropFromJson(scope, myJson, "r");
     std::string s1 = "r.DoubleCase == 3.141;";
     std::string s2 = "r.IntegerCase == 2;";
     std::string s3 = "r.BoolenCase == true;";

--- a/tests/model_enforcer_test.cpp
+++ b/tests/model_enforcer_test.cpp
@@ -504,6 +504,25 @@ TEST(TestModelEnforcer, TestRBACModelWithPattern) {
     scope = InitializeParams("bob", "/pen2/2", "GET");
     TestEnforce(e, scope, true);
 }
+
+TEST(TestModelEnforcer, TestABACModelWithJson) {
+    using json = nlohmann::json;
+
+    json obj = {
+            {"Owner", "alice"},
+        };
+    auto objPtr = std::make_shared<json>(obj);
+
+    casbin::DataMap mapParams = {{"sub", "alice"}, {"obj", objPtr}, {"act", "write"}};
+    casbin::DataList listParams = {"alice", objPtr, "write"}; 
+    casbin::DataVector vectorParams = {"alice", objPtr, "write"}; 
+
+    casbin::Enforcer e(abac_model_path);
+
+    ASSERT_TRUE(e.Enforce(mapParams));
+    ASSERT_TRUE(e.Enforce(listParams));
+    ASSERT_TRUE(e.Enforce(vectorParams));
+}
 /*
 type testCustomRoleManager struct {}
 


### PR DESCRIPTION
Signed-off-by: stonex <1479765922@qq.com>

<!--
    We follow semantic pull requests. Make sure you sign-off and format every commit message
    as well as the PR title as specified in 
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

    Eg. feat: New feature name,
    fix: Some error, etc.
-->

### Description
+ Link to this [issue](https://github.com/casbin/casbin-cpp/issues/165).
+ Add a json parser to build duktape object.
+ Test `double`, `int`, `bool`, `string` and `object`.

