### PR TITLE
feat: add eval regex and test

### DIFF
--- a/casbin/CMakeLists.txt
+++ b/casbin/CMakeLists.txt
@@ -66,6 +66,7 @@ set(CASBIN_SOURCE_FILES
     util/split.cpp
     util/ticker.cpp
     util/trim.cpp
+    util/eval.cpp
 )
 
 # Setting to C++ standard to C++17

--- a/casbin/util/eval.cpp
+++ b/casbin/util/eval.cpp
@@ -1,0 +1,65 @@
+/*
+* Copyright 2020 The casbin Authors. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "pch.h"
+
+#ifndef EVAL_CPP
+#define EVAL_CPP
+
+#include <regex>
+
+#include "./util.h"
+
+namespace casbin {
+
+std::regex evalReg("\\beval\\(([^)]*)\\)", 
+    std::regex_constants::icase);
+
+// HasEval determine whether matcher contains function eval
+bool HasEval(const std::string& s) {
+    return std::regex_search(s, evalReg);
+}
+
+// ReplaceEvalWithMap replace function eval with the value of its parameters via given sets.
+std::string ReplaceEvalWithMap(const std::string& src, std::unordered_map<std::string, std::string>& sets) {
+    std::string replacedExp = "";
+    std::string srcCpy = src;
+    std::smatch m;
+
+    while (std::regex_search(srcCpy, m, evalReg)) {
+        if (m.empty()) {
+            return src;
+        }
+        std::string key = m[1];
+        bool found = sets.find(key) != sets.end();
+
+        replacedExp += m.prefix();
+        if (!found) {
+            replacedExp += m[0];
+        } else {
+            replacedExp += sets[key];
+        }
+        srcCpy = m.suffix();
+    }
+
+    replacedExp += srcCpy;
+
+    return replacedExp;
+}
+
+} // namespace casbin
+
+#endif // EVAL_CPP

--- a/casbin/util/util.h
+++ b/casbin/util/util.h
@@ -65,6 +65,12 @@ std::string& RTrim(std::string& str, const std::string& chars = "\t\n\v\f\r ");
  
 std::string Trim(std::string& str, const std::string& chars = "\t\n\v\f\r ");
 
+// HasEval determine whether matcher contains function eval
+bool HasEval(const std::string& s);
+
+// ReplaceEvalWithMap replace function eval with the value of its parameters via given sets.
+std::string ReplaceEvalWithMap(const std::string& src, std::unordered_map<std::string, std::string>& sets);
+
 } // namespace casbin
 
 #endif

--- a/include/casbin/casbin_helpers.h
+++ b/include/casbin/casbin_helpers.h
@@ -635,6 +635,12 @@ namespace casbin {
 
     std::string Trim(std::string& str, const std::string& chars = "\t\n\v\f\r ");
 
+    // HasEval determine whether matcher contains function eval
+    bool HasEval(const std::string& s);
+
+    // ReplaceEvalWithMap replace function eval with the value of its parameters via given sets.
+    std::string ReplaceEvalWithMap(const std::string& src, std::unordered_map<std::string, std::string>& sets);
+
     // Exception class for Casbin Adapter Exception.
     class CasbinAdapterException : std::logic_error {
     public:


### PR DESCRIPTION
Signed-off-by: stonex <1479765922@qq.com>

<!--
    We follow semantic pull requests. Make sure you sign-off and format every commit message
    as well as the PR title as specified in 
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

    Eg. feat: New feature name,
    fix: Some error, etc.
-->


### Description
+ In adac model, we need test `eavl()` whether in the model matcher expression. Add a regex to test whether has `eval`.
+ `ReplaceEvalWithMap` replace the `eval(tokens)` by tokens value.
+ Add an unit test for `HasEval()` and `ReplaceEvalWithMap()`.
