### PR TITLE
feat: Add benchmarks for exprtk evaluator.

### DIFF
--- a/casbin/enforcer.cpp
+++ b/casbin/enforcer.cpp
@@ -59,18 +59,17 @@ bool Enforcer::m_enforce(const std::string& matcher, std::shared_ptr<IEvaluator>
         for (auto [assertion_name, assertion] : m_model->m["g"].assertion_map) {
             std::shared_ptr<RoleManager>& rm = assertion->rm;
 
-            if (dynamic_cast<DuktapeEvaluator*>(m_func_map.evalator.get()) != nullptr) {
                 int char_count = static_cast<int>(std::count(assertion->value.begin(), assertion->value.end(), '_'));
                 size_t index = exp_string.find(assertion_name + "(");
 
-                if (index != std::string::npos)
-                    exp_string.insert(index + assertion_name.length() + 1, "rm, ");
+                if (dynamic_cast<DuktapeEvaluator*>(m_func_map.evalator.get()) != nullptr) {
+                    if (index != std::string::npos)
+                        exp_string.insert(index + assertion_name.length() + 1, "rm, ");
 
-                m_func_map.evalator->LoadGFunction(rm, assertion_name, char_count + 1);
-            } else {
-                m_func_map.evalator->LoadGFunction(rm, assertion_name, 0);
-            }
-
+                    m_func_map.evalator->LoadGFunction(rm, assertion_name, char_count + 1);
+                } else {
+                    m_func_map.evalator->LoadGFunction(rm, assertion_name, char_count);
+                }
         }
     }
 

--- a/casbin/enforcer.cpp
+++ b/casbin/enforcer.cpp
@@ -102,7 +102,7 @@ bool Enforcer::m_enforce(const std::string& matcher, std::shared_ptr<IEvaluator>
             m_log.LogPrint("Policy Rule: ", p_vals);
             if(p_tokens.size() != p_vals.size())
                 return false;
-            m_func_map.evalator->Clean(m_model->m["p"]);
+            m_func_map.evalator->Clean(m_model->m["p"], false);
             m_func_map.evalator->InitialObject("p");
             for(int j = 0 ; j < p_tokens.size() ; j++) {
                 size_t index = p_tokens[j].find("_");
@@ -173,7 +173,7 @@ bool Enforcer::m_enforce(const std::string& matcher, std::shared_ptr<IEvaluator>
     } else {
         // Push initial value for p in symbol table
         // If p don't in symbol table, the evaluate result will be invalid.
-        m_func_map.evalator->Clean(m_model->m["p"]);
+        m_func_map.evalator->Clean(m_model->m["p"], false);
         m_func_map.evalator->InitialObject("p");
         for(int j = 0 ; j < p_tokens.size() ; j++) {
             size_t index = p_tokens[j].find("_");

--- a/casbin/enforcer.cpp
+++ b/casbin/enforcer.cpp
@@ -367,6 +367,11 @@ void Enforcer::SetWatcher(std::shared_ptr<Watcher> watcher) {
     watcher->SetUpdateCallback(func);
 }
 
+// SetWatcher sets the current evaluator.
+void Enforcer::SetEvaluator(std::shared_ptr<IEvaluator> evaluator) {
+    this->m_evalator = evaluator;
+}
+
 // GetRoleManager gets the current role manager.
 std::shared_ptr<RoleManager> Enforcer ::GetRoleManager() {
     return this->rm;

--- a/casbin/model/evaluator.cpp
+++ b/casbin/model/evaluator.cpp
@@ -20,26 +20,35 @@
 
 namespace casbin {
     bool ExprtkEvaluator::Eval(const std::string& expression_string) {
-        expression.register_symbol_table(symbol_table);
-        // replace (&& -> and), (|| -> or)
-        auto replaced_string = std::regex_replace(expression_string, std::regex("&&"), "and");
-        replaced_string = std::regex_replace(replaced_string, std::regex("\\|{2}"), "or");
-        // replace string "" -> ''
-        replaced_string = std::regex_replace(replaced_string, std::regex("\""), "\'");
+        if (this->expression_string_ != expression_string) {
+            this->expression_string_ = expression_string;
+            // replace (&& -> and), (|| -> or)
+            auto replaced_string = std::regex_replace(expression_string, std::regex("&&"), "and");
+            replaced_string = std::regex_replace(replaced_string, std::regex("\\|{2}"), "or");
+            // replace string "" -> ''
+            replaced_string = std::regex_replace(replaced_string, std::regex("\""), "\'");
+            
+            return parser.compile(replaced_string, expression);
+        }
 
-        return parser.compile(replaced_string, expression);
+        return this->parser.error_count() == 0;
     }
 
-    void ExprtkEvaluator::InitialObject(std::string identifier) {
+    void ExprtkEvaluator::InitialObject(const std::string& identifier) {
         // symbol_table.add_stringvar("");
     }
 
-    void ExprtkEvaluator::PushObjectString(std::string target, std::string proprity, const std::string& var) {
+    void ExprtkEvaluator::PushObjectString(const std::string& target, const std::string& proprity, const std::string& var) {
         auto identifier = target + "." + proprity;
-        this->symbol_table.add_stringvar(identifier, const_cast<std::string&>(var));
+
+        if (!symbol_table.symbol_exists(identifier)) {
+            identifiers_[identifier] = std::make_unique<std::string>("");
+            this->symbol_table.add_stringvar(identifier, *identifiers_[identifier]);
+        }
+        symbol_table.get_stringvar(identifier)->ref() = var;
     }
 
-    void ExprtkEvaluator::PushObjectJson(std::string target, std::string proprity, const nlohmann::json& var) {
+    void ExprtkEvaluator::PushObjectJson(const std::string& target, const std::string& proprity, const nlohmann::json& var) {
         auto identifier = target + "." + proprity;
         // this->symbol_table.add_stringvar(identifier, const_cast<std::string&>(var));
     }
@@ -73,14 +82,18 @@ namespace casbin {
     }
 
     bool ExprtkEvaluator::GetBoolen() {
-        return expression.value();
+        return bool(this->expression);
     }
 
     float ExprtkEvaluator::GetFloat() {
         return expression.value();
     }
 
-    void ExprtkEvaluator::Clean(AssertionMap& section) {
+    void ExprtkEvaluator::Clean(AssertionMap& section, bool after_enforce) {
+        if (after_enforce == false) {
+            return;
+        }
+
         for (auto& [assertion_name, assertion]: section.assertion_map) {
             std::vector<std::string> raw_tokens = assertion->tokens;
 
@@ -88,11 +101,14 @@ namespace casbin {
                 size_t index = raw_tokens[j].find("_");
                 std::string token = raw_tokens[j].substr(index + 1);
                 auto identifier = assertion_name + "." + token;
-                if (symbol_table.get_stringvar(identifier) != nullptr) {
+                if (symbol_table.symbol_exists(identifier)) {
                     symbol_table.remove_stringvar(identifier);
                 }
             }
         }
+        this->expression_string_ = "";
+        this->Functions.clear();
+        this->identifiers_.clear();
     }
 
     void ExprtkEvaluator::AddFunction(const std::string& func_name, std::shared_ptr<exprtk_func_t> func) {
@@ -108,21 +124,24 @@ namespace casbin {
         for (auto& var: var_list) {
             printf(" %s: %s\n" , var.c_str(), symbol_table.get_stringvar(var)->ref().c_str());
         }
+        printf("Current error: %s\n", parser.error().c_str());
+        // printf("Current exprsio string: %s\n", parser.current_token);
+        printf("Current value: %d\n", bool(this->expression));
     }
 
     bool DuktapeEvaluator::Eval(const std::string& expression) {
         return casbin::Eval(scope, expression);
     }
 
-    void DuktapeEvaluator::InitialObject(std::string identifier) {
+    void DuktapeEvaluator::InitialObject(const std::string& identifier) {
         PushObject(scope, identifier);
     }
 
-    void DuktapeEvaluator::PushObjectString(std::string target, std::string proprity, const std::string& var) {
+    void DuktapeEvaluator::PushObjectString(const std::string& target, const std::string& proprity, const std::string& var) {
         PushStringPropToObject(scope, target, var, proprity);
     }
 
-    void DuktapeEvaluator::PushObjectJson(std::string target, std::string proprity, const nlohmann::json& var) {
+    void DuktapeEvaluator::PushObjectJson(const std::string& target, const std::string& proprity, const nlohmann::json& var) {
         PushObject(scope, proprity);
         PushObjectPropFromJson(scope, var, proprity);
         PushObjectPropToObject(scope, target, proprity);
@@ -187,7 +206,7 @@ namespace casbin {
         return casbin::GetFloat(scope);
     }
 
-    void DuktapeEvaluator::Clean(AssertionMap& section) {
+    void DuktapeEvaluator::Clean(AssertionMap& section, bool after_enforce) {
         if (scope != nullptr) {
             for (auto& [assertion_name, assertion]: section.assertion_map) {
                 std::vector<std::string> raw_tokens = assertion->tokens;

--- a/casbin/model/evaluator.cpp
+++ b/casbin/model/evaluator.cpp
@@ -45,7 +45,11 @@ namespace casbin {
     }
 
     void ExprtkEvaluator::LoadFunctions() {
-        
+        AddFunction("keyMatch", ExprtkFunctionFactory::GetExprtkFunction(ExprtkFunctionType::KeyMatch, 2));
+        AddFunction("keyMatch2", ExprtkFunctionFactory::GetExprtkFunction(ExprtkFunctionType::KeyMatch2, 2));
+        AddFunction("keyMatch3", ExprtkFunctionFactory::GetExprtkFunction(ExprtkFunctionType::KeyMatch3, 2));
+        AddFunction("regexMatch", ExprtkFunctionFactory::GetExprtkFunction(ExprtkFunctionType::RegexMatch, 2));
+        AddFunction("ipMatch", ExprtkFunctionFactory::GetExprtkFunction(ExprtkFunctionType::IpMatch, 2));
     }
 
     void ExprtkEvaluator::LoadGFunction(std::shared_ptr<RoleManager> rm, const std::string& name, int narg) {

--- a/casbin/model/evaluator.cpp
+++ b/casbin/model/evaluator.cpp
@@ -112,8 +112,13 @@ namespace casbin {
     }
 
     void ExprtkEvaluator::AddFunction(const std::string& func_name, std::shared_ptr<exprtk_func_t> func) {
-        this->Functions.push_back(func);
-        symbol_table.add_function(func_name, *func);
+        if (func != nullptr) {
+            this->Functions.push_back(func);
+            if (symbol_table.symbol_exists(func_name)) {
+                symbol_table.remove_function(func_name);
+            } 
+            symbol_table.add_function(func_name, *func);
+        }
     }
 
     void ExprtkEvaluator::PrintSymbol() {

--- a/casbin/model/evaluator.cpp
+++ b/casbin/model/evaluator.cpp
@@ -94,18 +94,7 @@ namespace casbin {
             return;
         }
 
-        for (auto& [assertion_name, assertion]: section.assertion_map) {
-            std::vector<std::string> raw_tokens = assertion->tokens;
-
-            for(int j = 0 ; j < raw_tokens.size() ; j++) {
-                size_t index = raw_tokens[j].find("_");
-                std::string token = raw_tokens[j].substr(index + 1);
-                auto identifier = assertion_name + "." + token;
-                if (symbol_table.symbol_exists(identifier)) {
-                    symbol_table.remove_stringvar(identifier);
-                }
-            }
-        }
+        this->symbol_table.clear();
         this->expression_string_ = "";
         this->Functions.clear();
         this->identifiers_.clear();
@@ -114,9 +103,6 @@ namespace casbin {
     void ExprtkEvaluator::AddFunction(const std::string& func_name, std::shared_ptr<exprtk_func_t> func) {
         if (func != nullptr) {
             this->Functions.push_back(func);
-            if (symbol_table.symbol_exists(func_name)) {
-                symbol_table.remove_function(func_name);
-            } 
             symbol_table.add_function(func_name, *func);
         }
     }

--- a/casbin/model/evaluator.cpp
+++ b/casbin/model/evaluator.cpp
@@ -16,7 +16,6 @@
 #include <regex>
 
 #include "casbin/model/evaluator.h"
-#include "casbin/model/exprtk_config.h"
 #include "casbin/util/util.h"
 
 namespace casbin {
@@ -50,7 +49,7 @@ namespace casbin {
     }
 
     void ExprtkEvaluator::LoadGFunction(std::shared_ptr<RoleManager> rm, const std::string& name, int narg) {
-        std::shared_ptr<exprtk_func_t> func = std::make_shared<ExprtkGFunction<numerical_type>>(rm);
+        auto func = ExprtkFunctionFactory::GetExprtkFunction(ExprtkFunctionType::Gfunction, narg, rm);
         this->AddFunction(name, func);
     }
 
@@ -59,6 +58,9 @@ namespace casbin {
     }
 
     Type ExprtkEvaluator::CheckType() {
+        if (parser.error_count() != 0) {
+            throw parser.error();
+        }
         if (expression.value() == float(0) || expression.value() == float(1)) {
             return Type::Bool;
         } else {

--- a/include/casbin/enforcer.h
+++ b/include/casbin/enforcer.h
@@ -127,6 +127,8 @@ class Enforcer : public IEnforcer {
         void SetAdapter(std::shared_ptr<Adapter> adapter);
         // SetWatcher sets the current watcher.
         void SetWatcher(std::shared_ptr<Watcher> watcher);
+        // SetWatcher sets the current watcher.
+        void SetEvaluator(std::shared_ptr<IEvaluator> evaluator);
         // GetRoleManager gets the current role manager.
         std::shared_ptr<RoleManager> GetRoleManager();
         // SetRoleManager sets the current role manager.

--- a/include/casbin/model/evaluator.h
+++ b/include/casbin/model/evaluator.h
@@ -34,11 +34,11 @@ namespace casbin {
             std::list<std::string> func_list;
             virtual bool Eval(const std::string& expression) = 0;
 
-            virtual void InitialObject(std::string target) = 0;
+            virtual void InitialObject(const std::string& target) = 0;
 
-            virtual void PushObjectString(std::string target, std::string proprity, const std::string& var) = 0;
+            virtual void PushObjectString(const std::string& target, const std::string& proprity, const std::string& var) = 0;
 
-            virtual void PushObjectJson(std::string target, std::string proprity, const nlohmann::json& var) = 0;
+            virtual void PushObjectJson(const std::string& target, const std::string& proprity, const nlohmann::json& var) = 0;
 
             virtual void LoadFunctions() = 0;
 
@@ -52,23 +52,28 @@ namespace casbin {
 
             virtual float GetFloat() = 0;
 
-            virtual void Clean(AssertionMap& section) = 0;
+            virtual void Clean(AssertionMap& section, bool after_enforce = true) = 0;
     };
 
     class ExprtkEvaluator : public IEvaluator {
         private:
+            std::string expression_string_;
             symbol_table_t symbol_table;
             expression_t expression;
             parser_t parser;
             std::vector<std::shared_ptr<exprtk_func_t>> Functions;
+            std::unordered_map<std::string, std::unique_ptr<std::string>> identifiers_;
         public:
+            ExprtkEvaluator() {
+                this->expression.register_symbol_table(this->symbol_table);
+            };
             bool Eval(const std::string& expression);
 
-            void InitialObject(std::string target);
+            void InitialObject(const std::string& target);
 
-            void PushObjectString(std::string target, std::string proprity, const std::string& var);
+            void PushObjectString(const std::string& target, const std::string& proprity, const std::string& var);
 
-            void PushObjectJson(std::string target, std::string proprity, const nlohmann::json& var);
+            void PushObjectJson(const std::string& target, const std::string& proprity, const nlohmann::json& var);
 
             void LoadFunctions();
 
@@ -82,7 +87,7 @@ namespace casbin {
 
             float GetFloat();
 
-            void Clean(AssertionMap& section);
+            void Clean(AssertionMap& section, bool after_enforce = true);
 
             void PrintSymbol();
 
@@ -103,11 +108,11 @@ namespace casbin {
 
             bool Eval(const std::string& expression);
 
-            void InitialObject(std::string target);
+            void InitialObject(const std::string& target);
             
-            void PushObjectString(std::string target, std::string proprity, const  std::string& var);
+            void PushObjectString(const std::string& target, const std::string& proprity, const  std::string& var);
             
-            void PushObjectJson(std::string target, std::string proprity, const nlohmann::json& var);
+            void PushObjectJson(const std::string& target, const std::string& proprity, const nlohmann::json& var);
 
             void LoadFunctions();
 
@@ -121,7 +126,7 @@ namespace casbin {
 
             float GetFloat();
 
-            void Clean(AssertionMap& section);
+            void Clean(AssertionMap& section, bool after_enforce = true);
             // For duktape
             void AddFunction(const std::string& func_name, Function f, Index nargs);
 

--- a/include/casbin/model/evaluator.h
+++ b/include/casbin/model/evaluator.h
@@ -25,15 +25,9 @@
 #include "../exprtk/exprtk.hpp"
 #include "./scope_config.h"
 #include "./model.h"
+#include "./exprtk_config.h"
 
 namespace casbin {
-
-    using numerical_type = float;
-
-    using symbol_table_t = exprtk::symbol_table<numerical_type>;
-    using expression_t = exprtk::expression<numerical_type>;
-    using parser_t = exprtk::parser<numerical_type>;
-    using exprtk_func_t = exprtk::igeneric_function<numerical_type>;
 
     class IEvaluator {
         public:

--- a/include/casbin/model/exprtk_config.h
+++ b/include/casbin/model/exprtk_config.h
@@ -169,31 +169,32 @@ namespace casbin {
     class ExprtkFunctionFactory {
         public:
             static std::shared_ptr<exprtk_func_t> GetExprtkFunction(ExprtkFunctionType type, int narg, std::shared_ptr<RoleManager> rm = nullptr) {
-                if (type == ExprtkFunctionType::Gfunction) {
-                    std::string idenfier(narg, 'S');
-                    return std::make_shared<ExprtkGFunction>(idenfier, rm);
-                } else if (type != ExprtkFunctionType::Unknown) {
-                    std::string idenfier(narg, 'S');
-                    auto ret = std::make_shared<ExprtkOtherFunction>();
-                    if (type == ExprtkFunctionType::KeyMatch) {
-                        ret.reset(new ExprtkOtherFunction(idenfier, KeyMatch));
-                        return ret;
-                    } else if (type == ExprtkFunctionType::KeyMatch2) {
-                        ret.reset(new ExprtkOtherFunction(idenfier, KeyMatch2));
-                        return ret;
-                    } else if (type == ExprtkFunctionType::KeyMatch3) {
-                        ret.reset(new ExprtkOtherFunction(idenfier, KeyMatch3));
-                        return ret;
-                    } else if (type == ExprtkFunctionType::IpMatch) {
-                        ret.reset(new ExprtkOtherFunction(idenfier, IPMatch));
-                        return ret;
-                    } else if (type == ExprtkFunctionType::RegexMatch) {
-                        ret.reset(new ExprtkOtherFunction(idenfier, RegexMatch));
-                        return ret;
-                    }
+                std::string idenfier(narg, 'S');
+                std::shared_ptr<exprtk_func_t> func = nullptr;
+                switch (type) {
+                    case ExprtkFunctionType::Gfunction:
+                        func = std::make_shared<ExprtkGFunction>(idenfier, rm);
+                        break;
+                    case ExprtkFunctionType::KeyMatch:
+                        func.reset(new ExprtkOtherFunction(idenfier, KeyMatch));
+                        break;
+                    case ExprtkFunctionType::KeyMatch2:
+                        func.reset(new ExprtkOtherFunction(idenfier, KeyMatch));
+                        break;
+                    case ExprtkFunctionType::KeyMatch3:
+                        func.reset(new ExprtkOtherFunction(idenfier, KeyMatch));
+                        break;
+                    case ExprtkFunctionType::IpMatch:
+                        func.reset(new ExprtkOtherFunction(idenfier, KeyMatch));
+                        break;
+                    case ExprtkFunctionType::RegexMatch:
+                        func.reset(new ExprtkOtherFunction(idenfier, KeyMatch));
+                        break;
+                    default:
+                        func = nullptr;
                 }
 
-                return nullptr;
+                return func;
             }
     };
 }

--- a/include/casbin/model/exprtk_config.h
+++ b/include/casbin/model/exprtk_config.h
@@ -187,10 +187,13 @@ namespace casbin {
                     } else if (type == ExprtkFunctionType::IpMatch) {
                         ret.reset(new ExprtkOtherFunction(idenfier, IPMatch));
                         return ret;
+                    } else if (type == ExprtkFunctionType::RegexMatch) {
+                        ret.reset(new ExprtkOtherFunction(idenfier, RegexMatch));
+                        return ret;
                     }
-                } else {
-                    return nullptr;
                 }
+
+                return nullptr;
             }
     };
 }

--- a/tests/benchmarks/model_b.cpp
+++ b/tests/benchmarks/model_b.cpp
@@ -37,18 +37,27 @@ static void BenchmarkRaw(benchmark::State& state) {
 
 BENCHMARK(BenchmarkRaw);
 
+template <typename T>
 static void BenchmarkBasicModel(benchmark::State& state) {
     casbin::Enforcer e(basic_model_path, basic_policy_path);
+    auto evaluator = std::make_shared<T>();
+    e.SetEvaluator(evaluator);
+
     casbin::DataList params = {"alice", "data1", "read"};
 
     for(auto _ : state)
         e.Enforce(params);
 }
 
-BENCHMARK(BenchmarkBasicModel);
+BENCHMARK_TEMPLATE(BenchmarkBasicModel, casbin::DuktapeEvaluator);
+BENCHMARK_TEMPLATE(BenchmarkBasicModel, casbin::ExprtkEvaluator);
 
+template <typename T>
 static void BenchmarkRBACModel(benchmark::State& state) {
     casbin::Enforcer e(rbac_model_path, rbac_policy_path);
+
+    auto evaluator = std::make_shared<T>();
+    e.SetEvaluator(evaluator);
 
     casbin::DataList params = {"alice", "data2", "read"};
 
@@ -56,10 +65,14 @@ static void BenchmarkRBACModel(benchmark::State& state) {
         e.Enforce(params);
 }
 
-BENCHMARK(BenchmarkRBACModel);
+BENCHMARK_TEMPLATE(BenchmarkRBACModel, casbin::DuktapeEvaluator);
+BENCHMARK_TEMPLATE(BenchmarkRBACModel, casbin::ExprtkEvaluator);
 
+template <typename T>
 static void BenchmarkRBACModelSmall(benchmark::State& state) {
     casbin::Enforcer e(rbac_model_path);
+    auto evaluator = std::make_shared<T>();
+    e.SetEvaluator(evaluator);
 
     // 100 roles, 10 resources.
     for(int i = 0; i < 100; ++i)
@@ -74,16 +87,21 @@ static void BenchmarkRBACModelSmall(benchmark::State& state) {
         e.Enforce(params);
 }
 
-BENCHMARK(BenchmarkRBACModelSmall);
+BENCHMARK_TEMPLATE(BenchmarkRBACModelSmall, casbin::DuktapeEvaluator);
+BENCHMARK_TEMPLATE(BenchmarkRBACModelSmall, casbin::ExprtkEvaluator);
 
+template <typename T>
 static void BenchmarkRBACModelWithResourceRoles(benchmark::State& state) {
     casbin::Enforcer e(rbac_with_resource_roles_model_path, rbac_with_resource_roles_policy_path);
+    auto evaluator = std::make_shared<T>();
+    e.SetEvaluator(evaluator);
     casbin::DataList params = {"alice", "data1", "read"};
     for (auto _ : state)
         e.Enforce(params);
 }
 
-BENCHMARK(BenchmarkRBACModelWithResourceRoles);
+BENCHMARK_TEMPLATE(BenchmarkRBACModelWithResourceRoles, casbin::DuktapeEvaluator);
+BENCHMARK_TEMPLATE(BenchmarkRBACModelWithResourceRoles, casbin::ExprtkEvaluator);
 
 static void BenchmarkRBACModelWithDomains(benchmark::State& state) {
     casbin::Enforcer e(rbac_with_domains_model_path, rbac_with_domains_policy_path);

--- a/tests/model_enforcer_test.cpp
+++ b/tests/model_enforcer_test.cpp
@@ -829,6 +829,23 @@ TEST(TestModelEnforcer, TestRBACModelWithPattern) {
     evaluator = InitializeParams<casbin::DuktapeEvaluator>("bob", "/pen/2", "GET");
     TestEnforce(e, evaluator, true);
 
+    evaluator = InitializeParams<casbin::ExprtkEvaluator>("alice", "/book/1", "GET");
+    TestEnforce(e, evaluator, true);
+    evaluator = InitializeParams<casbin::ExprtkEvaluator>("alice", "/book/2", "GET");
+    TestEnforce(e, evaluator, true);
+    evaluator = InitializeParams<casbin::ExprtkEvaluator>("alice", "/pen/1", "GET");
+    TestEnforce(e, evaluator, true);
+    evaluator = InitializeParams<casbin::ExprtkEvaluator>("alice", "/pen/2", "GET");
+    TestEnforce(e, evaluator, false);
+    evaluator = InitializeParams<casbin::ExprtkEvaluator>("bob", "/book/1", "GET");
+    TestEnforce(e, evaluator, false);
+    evaluator = InitializeParams<casbin::ExprtkEvaluator>("bob", "/book/2", "GET");
+    TestEnforce(e, evaluator, false);
+    evaluator = InitializeParams<casbin::ExprtkEvaluator>("bob", "/pen/1", "GET");
+    TestEnforce(e, evaluator, true);
+    evaluator = InitializeParams<casbin::ExprtkEvaluator>("bob", "/pen/2", "GET");
+    TestEnforce(e, evaluator, true);
+
     // AddMatchingFunc() is actually setting a function because only one function is allowed,
     // so when we set "KeyMatch3", we are actually replacing "KeyMatch2" with "KeyMatch3".
     e.AddNamedMatchingFunc("p", "", casbin::KeyMatch3);

--- a/tests/model_enforcer_test.cpp
+++ b/tests/model_enforcer_test.cpp
@@ -645,8 +645,8 @@ TEST(TestModelEnforcer, TestRBACModelWithDomainsAtRuntimeMockAdapter) {
     evaluator = InitializeParamsWithDomains<casbin::ExprtkEvaluator>("alice", "domain3", "data1", "read");
     TestEnforce(e, evaluator, true);
 
-    evaluator = InitializeParamsWithDomains<casbin::DuktapeEvaluator>("alice", "domain1", "data1", "read");
-    TestEnforce(e, evaluator, true);
+    // evaluator = InitializeParamsWithDomains<casbin::DuktapeEvaluator>("alice", "domain1", "data1", "read");
+    // TestEnforce(e, evaluator, true);
     evaluator = InitializeParamsWithDomains<casbin::ExprtkEvaluator>("alice", "domain1", "data1", "read");
     TestEnforce(e, evaluator, true);
 

--- a/tests/model_enforcer_test.cpp
+++ b/tests/model_enforcer_test.cpp
@@ -645,8 +645,8 @@ TEST(TestModelEnforcer, TestRBACModelWithDomainsAtRuntimeMockAdapter) {
     evaluator = InitializeParamsWithDomains<casbin::ExprtkEvaluator>("alice", "domain3", "data1", "read");
     TestEnforce(e, evaluator, true);
 
-    // evaluator = InitializeParamsWithDomains<casbin::DuktapeEvaluator>("alice", "domain1", "data1", "read");
-    // TestEnforce(e, evaluator, true);
+    evaluator = InitializeParamsWithDomains<casbin::DuktapeEvaluator>("alice", "domain1", "data1", "read");
+    TestEnforce(e, evaluator, true);
     evaluator = InitializeParamsWithDomains<casbin::ExprtkEvaluator>("alice", "domain1", "data1", "read");
     TestEnforce(e, evaluator, true);
 


### PR DESCRIPTION
+ [feat: exprtk evaluator support RBAC with domain](https://github.com/casbin/casbin-cpp/commit/f7f7e3b83e79627a4653a481deea28eb89cbc389)
+ [feat: exprtk evaluator support rbac with pattern](https://github.com/casbin/casbin-cpp/commit/f0053dc88b83d6d726be683ab0214bc84041c968)
+ [feat: add benchmark for exprtk evaluator](https://github.com/casbin/casbin-cpp/commit/711c3b20a894661199c553ee3e19be0d0ac96e4a)
+ [perf: only compile once in Eval when eval string don't change.](https://github.com/casbin/casbin-cpp/commit/82bfac461b4e9c11454923a35e931c5092507cc9)
+ [fix: repair regex function and add function judge whether's null](https://github.com/casbin/casbin-cpp/commit/1bac8f190d7057a664f542ab1cfe472a5e24c9ab)
+ [fix: clean all symbol table to avoid haning pointer in exprtk.](https://github.com/casbin/casbin-cpp/commit/70b4b7749205fd356199fbd3bcd1c4c58cb7d386)

+ Exprt performance is much better than duktape, and we also have many  performace enhancement work to do with exprtk evaluator. And we need to wait exprtk new [feature](https://github.com/casbin/casbin-cpp/pull/185#issuecomment-1055326799), and we can achieve zero copy for enforce data in this way.
![image](https://user-images.githubusercontent.com/43725202/156724333-fe375be9-9942-4e86-817a-0813b1eaf47a.png)
+ I think maybe we should remove duktape evaluator, it's inefficient. @EmperorYP7 