### PR TITLE
fix: fix sync test by use base enforcer's ClearPolicy and BuildRoleLink.

### DIFF
--- a/casbin/enforcer.cpp
+++ b/casbin/enforcer.cpp
@@ -390,12 +390,13 @@ void Enforcer::ClearPolicy() {
 
 // LoadPolicy reloads the policy from file/database.
 void Enforcer::LoadPolicy() {
-    this->ClearPolicy();
+    // must use base's LoadPolicy to avoid dead lock
+    Enforcer::ClearPolicy();
     m_adapter->LoadPolicy(m_model);
     m_model->PrintPolicy();
 
     if(m_auto_build_role_links) {
-        this->BuildRoleLinks();
+        Enforcer::BuildRoleLinks();
     }
 }
 

--- a/tests/enforcer_synced_test.cpp
+++ b/tests/enforcer_synced_test.cpp
@@ -18,57 +18,58 @@
 
 #include <gtest/gtest.h>
 #include <casbin/casbin.h>
+#include "config_path.h"
 
 namespace {
 
-// void TestSyncFn(casbin::SyncedEnforcer& e, const std::string& sub, const std::string& obj, const std::string& act, bool control) {
-//     bool response = e.Enforce({ sub, obj, act });
-//     ASSERT_EQ(response, control);
-// }
+void TestSyncFn(casbin::SyncedEnforcer& e, const std::string& sub, const std::string& obj, const std::string& act, bool control) {
+    bool response = e.Enforce({ sub, obj, act });
+    ASSERT_EQ(response, control);
+}
 
-// TEST(TestEnforcerSynced, TestSync) {
-//     casbin::SyncedEnforcer e(basic_model_path, basic_policy_path);
+TEST(TestEnforcerSynced, TestSync) {
+    casbin::SyncedEnforcer e(basic_model_path, basic_policy_path);
 
-//     using namespace std::literals::chrono_literals;
-//     auto time1 = 200ms;
-//     e.StartAutoLoadPolicy(time1);
+    using namespace std::literals::chrono_literals;
+    auto time1 = 200ms;
+    e.StartAutoLoadPolicy(time1);
 
-//     TestSyncFn(e, "alice", "data1", "read", true);
-//     TestSyncFn(e, "alice", "data1", "write", false);
-//     TestSyncFn(e, "alice", "data2", "read", false);
-//     TestSyncFn(e, "alice", "data2", "write", false);
-//     TestSyncFn(e, "bob", "data1", "read", false);
-//     TestSyncFn(e, "bob", "data1", "write", false);
-//     TestSyncFn(e, "bob", "data2", "read", false);
-//     TestSyncFn(e, "bob", "data2", "write", true);
+    TestSyncFn(e, "alice", "data1", "read", true);
+    TestSyncFn(e, "alice", "data1", "write", false);
+    TestSyncFn(e, "alice", "data2", "read", false);
+    TestSyncFn(e, "alice", "data2", "write", false);
+    TestSyncFn(e, "bob", "data1", "read", false);
+    TestSyncFn(e, "bob", "data1", "write", false);
+    TestSyncFn(e, "bob", "data2", "read", false);
+    TestSyncFn(e, "bob", "data2", "write", true);
 
-//     std::this_thread::sleep_for(200ms);
-//     e.StopAutoLoadPolicy();
-// }
+    std::this_thread::sleep_for(200ms);
+    e.StopAutoLoadPolicy();
+}
 
-// TEST(TestEnforcerSynced, TestStopLoadPolicy) {
-//     casbin::SyncedEnforcer e(basic_model_path, basic_policy_path);
+TEST(TestEnforcerSynced, TestStopLoadPolicy) {
+    casbin::SyncedEnforcer e(basic_model_path, basic_policy_path);
 
-//     using namespace std::literals::chrono_literals;
-//     std::chrono::duration<int64_t, std::nano> t = 5ms;
+    using namespace std::literals::chrono_literals;
+    std::chrono::duration<int64_t, std::nano> t = 5ms;
 
-//     e.StartAutoLoadPolicy(t);
+    e.StartAutoLoadPolicy(t);
 
-//     EXPECT_EQ(e.IsAutoLoadingRunning(), true);
+    EXPECT_EQ(e.IsAutoLoadingRunning(), true);
 
-//     TestSyncFn(e , "alice", "data1", "read", true);
-//     TestSyncFn(e , "alice", "data1", "write", false);
-//     TestSyncFn(e , "alice", "data2", "read", false);
-//     TestSyncFn(e , "alice", "data2", "write", false);
-//     TestSyncFn(e , "bob", "data1", "read", false);
-//     TestSyncFn(e , "bob", "data1", "write", false);
-//     TestSyncFn(e , "bob", "data2", "read", false);
-//     TestSyncFn(e , "bob", "data2", "write", true);
+    TestSyncFn(e , "alice", "data1", "read", true);
+    TestSyncFn(e , "alice", "data1", "write", false);
+    TestSyncFn(e , "alice", "data2", "read", false);
+    TestSyncFn(e , "alice", "data2", "write", false);
+    TestSyncFn(e , "bob", "data1", "read", false);
+    TestSyncFn(e , "bob", "data1", "write", false);
+    TestSyncFn(e , "bob", "data2", "read", false);
+    TestSyncFn(e , "bob", "data2", "write", true);
 
-//     e.StopAutoLoadPolicy();
-//     std::this_thread::sleep_for(10ms);
+    e.StopAutoLoadPolicy();
+    std::this_thread::sleep_for(10ms);
 
-//     EXPECT_EQ(e.IsAutoLoadingRunning(), false);
-// }
+    EXPECT_EQ(e.IsAutoLoadingRunning(), false);
+}
 
 } // namespace


### PR DESCRIPTION
Signed-off-by: stonex <1479765922@qq.com>

<!--
    We follow semantic pull requests. Make sure you sign-off and format every commit message
    as well as the PR title as specified in 
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

    Eg. feat: New feature name,
    fix: Some error, etc.
-->

## Fixes #190 
+ I think the reason these test can't work may be the deadlock of policyMutex (lock it twice) in load policy.
+ Use base enforcer's ClearPolicy and BuildRoleLink.

