### PR TITLE
fix: add StringAdapter for Enforcer to pass policy as string

### DIFF
--- a/casbin/enforcer.cpp
+++ b/casbin/enforcer.cpp
@@ -228,7 +228,7 @@ Enforcer::Enforcer(const std::shared_ptr<Model>& m, std::shared_ptr<Adapter> ada
 
     this->Initialize();
 
-    if (m_adapter && m_adapter->file_path != "")
+    if (m_adapter && m_adapter->IsValid())
         this->LoadPolicy();
 }
 

--- a/casbin/persist/adapter.h
+++ b/casbin/persist/adapter.h
@@ -32,7 +32,6 @@ void LoadPolicyLine(std::string line, const std::shared_ptr<Model>& model);
  */
 class Adapter {
 public:
-    std::string file_path;
     bool filtered;
 
     /**
@@ -82,6 +81,8 @@ public:
     virtual void RemoveFilteredPolicy(std::string sec, std::string ptype, int field_index, std::vector<std::string> field_values) = 0;
 
     virtual bool IsFiltered() = 0;
+
+    virtual bool IsValid() = 0;
 };
 
 }; // namespace casbin

--- a/casbin/persist/file_adapter/file_adapter.cpp
+++ b/casbin/persist/file_adapter/file_adapter.cpp
@@ -113,6 +113,11 @@ bool FileAdapter ::IsFiltered() {
     return this->filtered;
 }
 
+// IsValid returns true if the loaded policy is valid.
+bool FileAdapter ::IsValid() {
+    return this->file_path != "";
+}
+
 } // namespace casbin
 
 #endif // FILE_ADAPTER_CPP

--- a/casbin/persist/file_adapter/file_adapter.h
+++ b/casbin/persist/file_adapter/file_adapter.h
@@ -9,6 +9,8 @@ namespace casbin {
 // It can load policy from file or save policy to file.
 class FileAdapter : virtual public Adapter {
 public:
+    std::string file_path;
+
     // NewAdapter is the constructor for Adapter.
     FileAdapter(std::string file_path);
 
@@ -35,6 +37,9 @@ public:
 
     // IsFiltered returns true if the loaded policy has been filtered.
     bool IsFiltered();
+
+    // IsValid returns true if the loaded policy is valid.
+    bool IsValid();
 };
 
 }; // namespace casbin

--- a/casbin/persist/string_adapter.cpp
+++ b/casbin/persist/string_adapter.cpp
@@ -1,0 +1,90 @@
+#include "casbin/pch.h"
+
+#ifndef STRING_ADAPTER_CPP
+#define STRING_ADAPTER_CPP
+
+#include <fstream>
+
+#include "casbin/exception/casbin_adapter_exception.h"
+#include "casbin/exception/io_exception.h"
+#include "casbin/exception/unsupported_operation_exception.h"
+#include "casbin/persist/string_adapter.h"
+#include "casbin/util/util.h"
+
+namespace casbin {
+
+// NewAdapter is the constructor for Adapter.
+StringAdapter ::StringAdapter(std::string line) {
+    this->line = line;
+    this->filtered = false;
+}
+
+std::shared_ptr<casbin::StringAdapter> StringAdapter::NewStringAdapter(std::string line) {
+    return std::make_shared<StringAdapter>(line);
+}
+
+// LoadPolicy loads all policy rules from the string buffer.
+void StringAdapter ::LoadPolicy(const std::shared_ptr<Model>& model) {
+    if (this->line == "")
+        throw CasbinAdapterException("Invalid line, line cannot be empty");
+
+    std::vector<std::string> strs = Split(this->line, "\n", -1);
+    for (int i = 0; i < strs.size(); i++)
+        LoadPolicyLine(strs[i], model);
+}
+
+// SavePolicy saves all policy rules to the string buffer.
+void StringAdapter ::SavePolicy(const std::shared_ptr<Model>& model) {
+    if (this->line == "") {
+        throw CasbinAdapterException("Invalid line, line cannot be empty");
+    }
+
+    std::string tmp;
+
+    for (std::unordered_map<std::string, std::shared_ptr<Assertion>>::iterator it = model->m["p"].assertion_map.begin(); it != model->m["p"].assertion_map.end(); it++) {
+        for (int i = 0; i < it->second->policy.size(); i++) {
+            tmp += it->first + ", ";
+            tmp += ArrayToString(it->second->policy[i]);
+            tmp += "\n";
+        }
+    }
+
+    for (std::unordered_map<std::string, std::shared_ptr<Assertion>>::iterator it = model->m["g"].assertion_map.begin(); it != model->m["g"].assertion_map.end(); it++) {
+        for (int i = 0; i < it->second->policy.size(); i++) {
+            tmp += it->first + ", ";
+            tmp += ArrayToString(it->second->policy[i]);
+            tmp += "\n";
+        }
+    }
+
+    this->line = RTrim(tmp, "\n");
+}
+
+// AddPolicy adds a policy rule to the string buffer.
+void StringAdapter ::AddPolicy(std::string sec, std::string p_type, std::vector<std::string> rule) {
+    throw UnsupportedOperationException("not implemented");
+}
+
+// RemovePolicy removes a policy rule from the string buffer.
+void StringAdapter ::RemovePolicy(std::string sec, std::string p_type, std::vector<std::string> rule) {
+    this->line = "";
+}
+
+// RemoveFilteredPolicy removes policy rules that match the filter from the string buffer.
+void StringAdapter ::RemoveFilteredPolicy(std::string sec, std::string p_type, int field_index, std::vector<std::string> field_values) {
+    throw UnsupportedOperationException("not implemented");
+}
+
+// IsFiltered returns true if the loaded policy has been filtered.
+bool StringAdapter ::IsFiltered() {
+    return this->filtered;
+}
+
+// IsValid returns true if the loaded policy is valid.
+bool StringAdapter ::IsValid() {
+    return this->line != "";
+}
+
+} // namespace casbin
+
+#endif // STRING_ADAPTER_CPP

--- a/casbin/persist/string_adapter.h
+++ b/casbin/persist/string_adapter.h
@@ -1,0 +1,43 @@
+#ifndef CASBIN_CPP_PERSIST_STRING_ADAPTER_STRING_ADAPTER
+#define CASBIN_CPP_PERSIST_STRING_ADAPTER_STRING_ADAPTER
+
+#include "./adapter.h"
+
+namespace casbin {
+
+// Adapter is the string adapter for Casbin.
+// It can load policy from string buffer or save policy to string buffer.
+class StringAdapter : virtual public Adapter {
+public:
+    std::string line;
+
+    // NewAdapter is the constructor for Adapter.
+    StringAdapter(std::string line);
+
+    static std::shared_ptr<StringAdapter> NewStringAdapter(std::string line);
+
+    // LoadPolicy loads all policy rules from the string buffer.
+    void LoadPolicy(const std::shared_ptr<Model>& model);
+
+    // SavePolicy saves all policy rules to the string buffer.
+    void SavePolicy(const std::shared_ptr<Model>& model);
+
+    // AddPolicy adds a policy rule to the string buffer.
+    void AddPolicy(std::string sec, std::string p_type, std::vector<std::string> rule);
+
+    // RemovePolicy removes a policy rule from the string buffer.
+    void RemovePolicy(std::string sec, std::string p_type, std::vector<std::string> rule);
+
+    // RemoveFilteredPolicy removes policy rules that match the filter from the string buffer.
+    void RemoveFilteredPolicy(std::string sec, std::string p_type, int field_index, std::vector<std::string> field_values);
+
+    // IsFiltered returns true if the loaded policy has been filtered.
+    bool IsFiltered();
+
+    // IsValid returns true if the loaded policy is valid.
+    bool IsValid();
+};
+
+}; // namespace casbin
+
+#endif

--- a/include/casbin/persist/adapter.h
+++ b/include/casbin/persist/adapter.h
@@ -32,7 +32,6 @@ void LoadPolicyLine(std::string line, const std::shared_ptr<Model>& model);
  */
 class Adapter {
 public:
-    std::string file_path;
     bool filtered;
 
     /**
@@ -82,6 +81,8 @@ public:
     virtual void RemoveFilteredPolicy(std::string sec, std::string ptype, int field_index, std::vector<std::string> field_values) = 0;
 
     virtual bool IsFiltered() = 0;
+
+    virtual bool IsValid() = 0;
 };
 
 }; // namespace casbin

--- a/include/casbin/persist/file_adapter/file_adapter.h
+++ b/include/casbin/persist/file_adapter/file_adapter.h
@@ -9,6 +9,8 @@ namespace casbin {
 // It can load policy from file or save policy to file.
 class FileAdapter : virtual public Adapter {
 public:
+    std::string file_path;
+
     // NewAdapter is the constructor for Adapter.
     FileAdapter(std::string file_path);
 
@@ -35,6 +37,9 @@ public:
 
     // IsFiltered returns true if the loaded policy has been filtered.
     bool IsFiltered();
+
+    // IsValid returns true if the loaded policy is valid.
+    bool IsValid();
 };
 
 }; // namespace casbin

--- a/include/casbin/persist/string_adapter.h
+++ b/include/casbin/persist/string_adapter.h
@@ -1,0 +1,43 @@
+#ifndef CASBIN_CPP_PERSIST_STRING_ADAPTER_STRING_ADAPTER
+#define CASBIN_CPP_PERSIST_STRING_ADAPTER_STRING_ADAPTER
+
+#include "./adapter.h"
+
+namespace casbin {
+
+// Adapter is the string adapter for Casbin.
+// It can load policy from string buffer or save policy to string buffer.
+class StringAdapter : virtual public Adapter {
+public:
+    std::string line;
+
+    // NewAdapter is the constructor for Adapter.
+    StringAdapter(std::string line);
+
+    static std::shared_ptr<StringAdapter> NewStringAdapter(std::string line);
+
+    // LoadPolicy loads all policy rules from the string buffer.
+    void LoadPolicy(const std::shared_ptr<Model>& model);
+
+    // SavePolicy saves all policy rules to the string buffer.
+    void SavePolicy(const std::shared_ptr<Model>& model);
+
+    // AddPolicy adds a policy rule to the string buffer.
+    void AddPolicy(std::string sec, std::string p_type, std::vector<std::string> rule);
+
+    // RemovePolicy removes a policy rule from the string buffer.
+    void RemovePolicy(std::string sec, std::string p_type, std::vector<std::string> rule);
+
+    // RemoveFilteredPolicy removes policy rules that match the filter from the string buffer.
+    void RemoveFilteredPolicy(std::string sec, std::string p_type, int field_index, std::vector<std::string> field_values);
+
+    // IsFiltered returns true if the loaded policy has been filtered.
+    bool IsFiltered();
+
+    // IsValid returns true if the loaded policy is valid.
+    bool IsValid();
+};
+
+}; // namespace casbin
+
+#endif


### PR DESCRIPTION
fix: #200
### Description
I added `void LoadPolicy(std::string policy)` for Enforcer to pass policy to Adapter as a sting buffer, which could be called as the following code:
```
casbin::Enforcer e("./path/to/model.conf");
std::string policy = "p, alice, data1, read\np, bob, data2, write";
e.LoadPolicy(policy);
```
Since c++ doesn't support overloaded functions with the same number and type of parameters, I didn't add a constructor like `Enforcer(const std::string& model_path, const std::string &policy)` in issue #200, that conflicts with `Enforcer(const std::string& model_path, const std::string& policy_file)`