### PR TITLE
perf: Remove shared_ptr in defaultRoleManager

### DIFF
--- a/casbin/rbac/default_role_manager.cpp
+++ b/casbin/rbac/default_role_manager.cpp
@@ -111,7 +111,7 @@ bool DefaultRoleManager ::HasRole(std::string name) {
     return ok;
 }
 
-Role* DefaultRoleManager ::CreateRole(std::string name) {
+Role* DefaultRoleManager ::CreateRole(const std::string& name) {
     Role* role;
     bool ok = this->all_roles.find(name) != this->all_roles.end();
     if (!ok) {

--- a/include/casbin/rbac/default_role_manager.h
+++ b/include/casbin/rbac/default_role_manager.h
@@ -36,7 +36,7 @@ private:
 public:
     std::string name;
 
-    static std::unique_ptr<Role> NewRole(std::string name);
+    static std::unique_ptr<Role> NewRole(const std::string& name);
 
     void AddRole(Role* role);
 

--- a/include/casbin/rbac/default_role_manager.h
+++ b/include/casbin/rbac/default_role_manager.h
@@ -19,7 +19,8 @@
 
 #include <unordered_map>
 
-#include "./role_manager.h"
+#include "casbin/pch.h"
+#include "casbin/rbac/role_manager.h"
 
 namespace casbin {
 
@@ -30,16 +31,16 @@ typedef bool (*MatchingFunc)(const std::string&, const std::string&);
  */
 class Role {
 private:
-    std::vector<std::shared_ptr<Role>> roles;
+    std::vector<Role*> roles;
 
 public:
     std::string name;
 
-    static std::shared_ptr<Role> NewRole(std::string name);
+    static std::unique_ptr<Role> NewRole(std::string name);
 
-    void AddRole(std::shared_ptr<Role> role);
+    void AddRole(Role* role);
 
-    void DeleteRole(std::shared_ptr<Role> role);
+    void DeleteRole(Role* role);
 
     bool HasRole(std::string name, int hierarchy_level);
 
@@ -52,14 +53,14 @@ public:
 
 class DefaultRoleManager : public RoleManager {
 private:
-    std::unordered_map<std::string, std::shared_ptr<Role>> all_roles;
+    std::unordered_map<std::string, std::unique_ptr<Role>> all_roles;
     bool has_pattern;
     int max_hierarchy_level;
     MatchingFunc matching_func;
 
     bool HasRole(std::string name);
 
-    std::shared_ptr<Role> CreateRole(std::string name);
+    Role* CreateRole(const std::string& name);
 
 public:
     /**


### PR DESCRIPTION
	* Share_ptr will cause performance loss.
	* Share_ptr may cause circular reference of Roles, which will cause memeory leak.
	* RoleManager take ownership of the resource, responsible for the application and release of Role*, Role only use this pointer.

Signed-off-by: Stonexx <1479765922@qq.com>

<!--
    We follow semantic pull requests. Make sure you sign-off and format every commit message
    as well as the PR title as specified in 
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

    Eg. feat: New feature name,
    fix: Some error, etc.
-->

## Fixes # <Enter the issue number>

### Description



### Screenshots/Testimonials


