### PR TITLE
fix: fix CI python issue

### DIFF
--- a/.github/workflows/python_binding.yml
+++ b/.github/workflows/python_binding.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ["3.6", "3.8", "3.10"]
+        python-version: ["3.8", "3.10"]
 
     runs-on: ${{ matrix.platform }}
 

--- a/cmake/modules/Findjson.cmake
+++ b/cmake/modules/Findjson.cmake
@@ -16,10 +16,6 @@ include(FetchContent)
 
 set(JSON_Install ON)
 
-FetchContent_Declare(json
-  GIT_REPOSITORY https://github.com/ArthurSonzogni/nlohmann_json_cmake_fetchcontent
-  GIT_PROGRESS TRUE
-  GIT_SHALLOW TRUE
-  GIT_TAG v3.10.5)
+FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz)
 
 FetchContent_MakeAvailable(json)

--- a/setup.py
+++ b/setup.py
@@ -141,10 +141,9 @@ setup(
     ext_modules=[CMakeExtension("")],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     license="Apache 2.0",
     classifiers=[
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin-cpp/issues/220

### Description
This PR replaces the JSON lib with the original repository, followed

> https://json.nlohmann.me/integration/cmake/#fetchcontent


Meanwhile, delete Python 3.6 version for the error:

> Error: Version 3.6 with arch x64 not found


