### PR TITLE
feat: refactor the code, rewrite the two functions m_enforce and MergeEffects

### DIFF
--- a/include/casbin/effect/default_effector.h
+++ b/include/casbin/effect/default_effector.h
@@ -29,7 +29,7 @@ public:
     /**
      * MergeEffects merges all matching results collected by the enforcer into a single decision.
      */
-    bool MergeEffects(std::string expr, std::vector<Effect> effects, std::vector<float> results);
+    Effect MergeEffects(const std::string& expr, const std::vector<Effect>& effects, const std::vector<float>& matches, int policyIndex, int policyLength, int& explainIndex) override;
 };
 
 } // namespace casbin

--- a/include/casbin/effect/effector.h
+++ b/include/casbin/effect/effector.h
@@ -34,10 +34,16 @@ public:
      *
      * @param expr the expression of [policy_effect].
      * @param effects the effects of all matched rules.
-     * @param results the matcher results of all matched rules.
+     * @param matches the matcher results of all matched rules.
+     * @param policyIndex the index of current policy.
+     * @param policyLength the length of the policy.
+     * @param explainIndex the index of explain
      * @return the final effect.
+     *      @retval Effect::Allow
+     *      @retval Effect::Deny
+     *      @retval Effect::Indeterminate (need further judgment)
      */
-    virtual bool MergeEffects(std::string expr, std::vector<Effect> effects, std::vector<float> results) = 0;
+    virtual Effect MergeEffects(const std::string& expr, const std::vector<Effect>& effects, const std::vector<float>& matches, int policyIndex, int policyLength, int& explainIndex) = 0;
 };
 
 } // namespace casbin

--- a/include/casbin/enforcer.h
+++ b/include/casbin/enforcer.h
@@ -49,7 +49,7 @@ private:
     // enforce use a custom matcher to decides whether a "subject" can access a "object"
     // with the operation "action", input parameters are usually: (matcher, sub, obj, act),
     // use model matcher by default when matcher is "".
-    bool m_enforce(const std::string& matcher, std::shared_ptr<IEvaluator> evalator);
+    bool m_enforce(const std::string& matcher, std::vector<std::string>& explains, std::shared_ptr<IEvaluator> evalator) override;
 
 public:
     std::shared_ptr<RoleManager> rm;

--- a/include/casbin/enforcer_interface.h
+++ b/include/casbin/enforcer_interface.h
@@ -58,7 +58,7 @@ public:
     virtual void EnableAutoSave(bool auto_save) = 0;
     virtual void EnableAutoBuildRoleLinks(bool auto_build_role_links) = 0;
     virtual void BuildRoleLinks() = 0;
-    virtual bool m_enforce(const std::string& matcher, std::shared_ptr<IEvaluator> evalator) = 0;
+    virtual bool m_enforce(const std::string& matcher, std::vector<std::string>& explains, std::shared_ptr<IEvaluator> evalator) = 0;
     virtual bool Enforce(std::shared_ptr<IEvaluator> evalator) = 0;
     virtual bool EnforceWithMatcher(const std::string& matcher, std::shared_ptr<IEvaluator> evalator) = 0;
     virtual std::vector<bool> BatchEnforce(const std::initializer_list<DataList>& requests) = 0;


### PR DESCRIPTION
Rewrite the two functions m_enforce and MerggeEffects to synchronize them with Casbin (Golang)


```golang
func (e *Enforcer) enforce(matcher string, explains *[]string, rvals ...interface{}) (ok bool, err error)

func (e *DefaultEffector) MergeEffects(expr string, effects []Effect, matches []float64, policyIndex int, policyLength int) (Effect, int, error)

```

```cpp
// before
bool Enforcer::m_enforce(const std::string& matcher, std::shared_ptr<IEvaluator> evalator)

bool DefaultEffector ::MergeEffects(std::string expr, std::vector<Effect> effects, std::vector<float> results) 

// now
bool Enforcer::m_enforce(const std::string& matcher, std::vector<std::string>& explains, std::shared_ptr<IEvaluator> evalator)

Effect DefaultEffector::MergeEffects(const std::string& expr, const std::vector<Effect>& effects, const std::vector<float>& matches, int policyIndex, int policyLength, int& explainIndex)


```