### PR TITLE
fix: set_target_properties's VERSION

### DIFF
--- a/casbin/CMakeLists.txt
+++ b/casbin/CMakeLists.txt
@@ -78,7 +78,7 @@ target_link_libraries(casbin PRIVATE nlohmann_json::nlohmann_json)
 
 set_target_properties(casbin PROPERTIES 
     PREFIX ""
-    VERSION ${CMAKE_PROJECT_VERSION}
+    VERSION ${PROJECT_VERSION}
 )
 
 if(WIN32 OR MSVC)


### PR DESCRIPTION
## Fixes

#205 

### Description

In "./casbin/CMakeLists.txt", line 79~82,
```cmake
set_target_properties(casbin PROPERTIES 
    PREFIX ""
    VERSION ${CMAKE_PROJECT_VERSION}
)
```
well, if i integrate `casbin-cpp` to my project as a thirdparty via cmake, the `VERSION` property will refer to my top project's `VERSION` property, cause `CMAKE_PROJECT_VERSION` means that, so it's unreasonable.

Instead, by

```cmake
set_target_properties(casbin PROPERTIES 
    PREFIX ""
    VERSION ${PROJECT_VERSION}
)
```
the `VERSION` property will refer to `casbin-cpp`'s top project's `VERSION` property, i think that's what we want.


