### PR TITLE
fix: add missing persist/string_adapter.cpp to CMakeLists.txt

### DIFF
--- a/casbin/CMakeLists.txt
+++ b/casbin/CMakeLists.txt
@@ -48,6 +48,7 @@ set(CASBIN_SOURCE_FILES
     persist/adapter.cpp
     persist/default_watcher.cpp
     persist/default_watcher_ex.cpp
+    persist/string_adapter.cpp
     rbac/default_role_manager.cpp
     util/array_equals.cpp
     util/array_remove_duplicates.cpp


### PR DESCRIPTION
### Description
Fixes `casbin/persist/string_adapter.h` not being able to include since linking will fail since `persist/string_adapter.cpp` is not included inside `casbin/CMakeLists.txt`.