### PR TITLE
feat: Do not use regex for simple pattern-replacements to improve performance

### DIFF
--- a/casbin/util/built_in_functions.cpp
+++ b/casbin/util/built_in_functions.cpp
@@ -38,17 +38,24 @@ namespace {
     static const std::regex capturingColonNonSlashRegex("(.*?):[^/]+(.*?)");
     static const std::regex enclosedPlaceHolderRegex("(.*?)\\{[^/]+?\\}(.*?)");
 
+    std::string ReplacePattern(std::string const& in, std::string const& pattern, std::string const& replacement) {
+        std::string result = in;
+        std::size_t pos = 0;
+        // Replace all occurrences of pattern with replacement
+        while ((pos = result.find(pattern, pos)) != std::string::npos) {
+            result.replace(pos, pattern.length(), replacement);
+            pos += replacement.length(); // Move over change
+        }
+        return result;
+    }
+
     std::string PrepareWildCardMatching(const std::string& value) {
-        static const std::regex pattern("/\\*");    
-        return std::regex_replace(value, pattern, "/.*");
+        return ReplacePattern(value, "/*", "/.*");
     }
 
     std::string EscapeCurlyBraces(const std::string& value) {
-        static const std::regex curlyBraceOpenPattern("\\{");
-        static const std::regex curlyBraceClosePattern("\\}");
-        
-        std::string intermediate = std::regex_replace(value, curlyBraceOpenPattern, "\\{");
-        return std::regex_replace(intermediate, curlyBraceClosePattern, "\\}");
+        std::string intermediate = ReplacePattern(value, "{", "\\{");
+        return ReplacePattern(intermediate, "}", "\\}");
     }
 }
 


### PR DESCRIPTION
### Description
Follow-up on #249.
Testing showed significant better performance when *not* using `std::regex` for simple pattern-replacements.

### Testimonials
Benchmarks built with CMAKE_BUILD_TYPE=Release in an ubuntu24.04 environment.

#### Key improvements
Performance of a bunch of benchmarks is improved
* almost 50% for e.g. `BenchmarkRBACModelSmall`
* about 20-30% for many other tests

#### Master
```
~/casbin-cpp/build/tests/benchmarks (master) $ make -C ../.. > /dev/null && sleep 60 && ./casbin_benchmark
2024-12-10T11:21:36+00:00
Running ./casbin_benchmark
Run on (16 X 400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 0.30, 0.54, 0.75
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
BenchmarkRaw                                    12.3 ns         12.3 ns     55008159
BenchmarkBasicModel                            21482 ns        21481 ns        70599
BenchmarkBasicModelLargeSize                   22535 ns        22534 ns        76155
BenchmarkRBACModel                             54962 ns        54959 ns        25536
BenchmarkRBACModelSizesSmall                  574150 ns       574119 ns         1000
BenchmarkRBACModelSmall                      2102158 ns      2102045 ns         1000
BenchmarkRBACModelWithResourceRoles            21984 ns        21983 ns        73480
BenchmarkRBACModelWithDomains                  21007 ns        21006 ns        63815
BenchmarkKeyMatchModel                         22016 ns        22015 ns        68877
BenchmarkRBACModelWithDeny                     62429 ns        62426 ns        10000
BenchmarkPriorityModel                         22142 ns        22138 ns        73641
BenchmarkCachedRaw                              12.4 ns         12.4 ns     54483456
BenchmarkCachedBasicModel                       57.6 ns         57.6 ns     11339292
BenchmarkCachedRBACModel                        54.7 ns         54.7 ns     11368001
BenchmarkCachedRBACModelSmall                   58.0 ns         58.0 ns     12232181
BenchmarkCachedRBACModelWithResourceRoles       54.8 ns         54.8 ns     11577444
BenchmarkCachedRBACModelWithDomains             66.1 ns         66.1 ns     10237541
BenchmarkCachedKeyMatchModel                    67.8 ns         67.8 ns      9778984
BenchmarkCachedRBACModelWithDeny                58.5 ns         58.5 ns     11291607
BenchmarkCachedPriorityModel                    57.8 ns         57.8 ns     11370908
BenchmarkVectorOperations                      61661 ns        61659 ns        11143
BenchmarkHasPolicySmall                        62884 ns        62881 ns        11041
BenchmarkAddPolicySmall                        83347 ns        83343 ns         9883
BenchmarkRemovePolicySmall                     61782 ns        61779 ns        11474
BenchmarkRoleManagerSmall                       7907 ns         7907 ns        88743
```

#### Modified version in this PR
```
~/casbin-cpp/build/tests/benchmarks (perf/pattern-replace-without-regex) $ make -C ../.. > /dev/null && sleep 60 && ./casbin_benchmark
2024-12-10T11:25:15+00:00
Running ./casbin_benchmark
Run on (16 X 400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 0.41, 0.52, 0.71
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
BenchmarkRaw                                    12.6 ns         12.6 ns     54473505
BenchmarkBasicModel                            15264 ns        15249 ns        81591
BenchmarkBasicModelLargeSize                   15519 ns        15496 ns        85887
BenchmarkRBACModel                             43033 ns        43000 ns        38733
BenchmarkRBACModelSizesSmall                  616423 ns       615774 ns         2217
BenchmarkRBACModelSmall                      1089734 ns      1088457 ns         1000
BenchmarkRBACModelWithResourceRoles            15087 ns        15072 ns        79431
BenchmarkRBACModelWithDomains                  15055 ns        15041 ns        71125
BenchmarkKeyMatchModel                         15489 ns        15461 ns        73908
BenchmarkRBACModelWithDeny                     58489 ns        58413 ns        18912
BenchmarkPriorityModel                         15314 ns        15299 ns        83362
BenchmarkCachedRaw                              12.3 ns         12.3 ns     55031998
BenchmarkCachedBasicModel                       56.7 ns         56.7 ns     11631141
BenchmarkCachedRBACModel                        58.8 ns         58.8 ns     11365562
BenchmarkCachedRBACModelSmall                   59.9 ns         59.9 ns     12175882
BenchmarkCachedRBACModelWithResourceRoles       61.0 ns         61.0 ns     11186549
BenchmarkCachedRBACModelWithDomains             67.0 ns         66.9 ns     10121554
BenchmarkCachedKeyMatchModel                    68.8 ns         68.7 ns     10104337
BenchmarkCachedRBACModelWithDeny                58.3 ns         58.3 ns     11499153
BenchmarkCachedPriorityModel                    59.1 ns         59.0 ns     11469047
BenchmarkVectorOperations                      61656 ns        61592 ns        11195
BenchmarkHasPolicySmall                        62860 ns        62798 ns        11185
BenchmarkAddPolicySmall                        82657 ns        82578 ns        10123
BenchmarkRemovePolicySmall                     61830 ns        61772 ns        11477
BenchmarkRoleManagerSmall                       8032 ns         8026 ns        86127
```